### PR TITLE
feat: Add translation generation script and internationalization support #47

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "cache:clear": "rm -rf .next/cache",
     "preinstall": "bun clean",
     "docker:build": "sh scripts/docker-build.sh",
-    "docker:build:local": "sh scripts/docker-build-local.sh"
+    "docker:build:local": "sh scripts/docker-build-local.sh",
+    "generate:translations": "bun generate:types && bun run scripts/generate-translations/index.ts"
   },
   "dependencies": {
     "@ai-sdk/deepseek": "^0.1.3",

--- a/scripts/generate-translations/config.ts
+++ b/scripts/generate-translations/config.ts
@@ -1,0 +1,52 @@
+import fs from 'fs'
+import path from 'path'
+import ts from 'typescript'
+import type { ConfigInfo } from './types'
+
+/**
+ * 从配置文件中获取配置信息
+ */
+export function getConfigInfo(configPath: string): ConfigInfo {
+  const actualConfigPath = configPath.includes('src')
+    ? configPath
+    : path.join(process.cwd(), 'src', path.basename(configPath))
+
+  const sourceFile = ts.createSourceFile(
+    actualConfigPath,
+    fs.readFileSync(actualConfigPath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  )
+
+  const info: ConfigInfo = {
+    collections: [],
+    globals: [],
+    blocks: new Set<string>(),
+  }
+
+  function visit(node: ts.Node) {
+    if (ts.isArrayLiteralExpression(node)) {
+      const parent = node.parent
+      if (ts.isPropertyAssignment(parent)) {
+        const propertyName = parent.name.getText()
+        if (propertyName === 'collections') {
+          node.elements.forEach((element) => {
+            if (ts.isIdentifier(element)) {
+              info.collections.push(element.text)
+            }
+          })
+        } else if (propertyName === 'globals') {
+          node.elements.forEach((element) => {
+            if (ts.isIdentifier(element)) {
+              info.globals.push(element.text)
+            }
+          })
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(sourceFile, visit)
+  return info
+}

--- a/scripts/generate-translations/field-collector.ts
+++ b/scripts/generate-translations/field-collector.ts
@@ -1,0 +1,274 @@
+import ts from 'typescript'
+import type { Node, PropertySignature } from 'typescript'
+import type { InterfaceMapping, ProcessFieldsOptions, TranslationTemplate } from './types'
+
+/**
+ * Extract description from JSDoc comments
+ */
+export function getJSDocDescription(node: Node, sourceFile: ts.SourceFile): string | undefined {
+  const jsDoc = ts.getJSDocTags(node)
+  let description: string | undefined
+
+  // Try to get description tag first
+  const descriptionTag = jsDoc.find((tag) => tag.tagName.getText() === 'description')
+  const tagComment = descriptionTag?.comment
+  if (tagComment) {
+    description =
+      typeof tagComment === 'string' ? tagComment : tagComment.map((part) => part.text).join('')
+  }
+
+  // If no description tag, try to get main comment
+  if (!description) {
+    const comments = ts.getLeadingCommentRanges(sourceFile.getFullText(), node.getFullStart())
+    const lastComment = comments?.[comments.length - 1]
+    if (lastComment) {
+      const commentText = sourceFile
+        .getFullText()
+        .slice(lastComment.pos, lastComment.end)
+        .replace(/\/\*\*|\*\/|\*/g, '')
+        .trim()
+      if (commentText) {
+        description = commentText
+      }
+    }
+  }
+
+  return description
+}
+
+/**
+ * Process fields and add them to the template
+ */
+export function processFields(
+  member: PropertySignature,
+  template: TranslationTemplate,
+  sourceFile: ts.SourceFile,
+  options: ProcessFieldsOptions = {},
+): void {
+  const { prefix = '', parentCollection, currentCollectionName } = options
+  const fieldName = member.name.getText().replace(/['"]/g, '')
+  const fullFieldName = prefix ? `${prefix}.${fieldName}` : fieldName
+  const targetCollection = parentCollection || currentCollectionName
+
+  if (!targetCollection) return
+
+  // Get field description
+  let description = getJSDocDescription(member, sourceFile)
+
+  // If no JSDoc comment, use field name as default description
+  if (!description && !['id', 'updatedAt', 'createdAt', 'blockType'].includes(fieldName)) {
+    // Convert camel case to space-separated words
+    description = fieldName
+      .replace(/([A-Z])/g, ' $1')
+      .toLowerCase()
+      .trim()
+      // Capitalize first letter
+      .replace(/^[a-z]/, (str) => str.toUpperCase())
+  }
+
+  if (!['id', 'updatedAt', 'createdAt', 'blockType'].includes(fieldName)) {
+    if (!template.collections[targetCollection]) {
+      template.collections[targetCollection] = {
+        singular: { en: '', zh: '' },
+        plural: { en: '', zh: '' },
+        fields: {},
+      }
+    }
+
+    template.collections[targetCollection]!.fields[fullFieldName] = {
+      en: description || fieldName,
+      zh: '',
+    }
+  }
+
+  // Process nested fields
+  if (member.type) {
+    if (ts.isTypeLiteralNode(member.type)) {
+      member.type.members.forEach((nestedMember) => {
+        if (ts.isPropertySignature(nestedMember)) {
+          processFields(nestedMember, template, sourceFile, {
+            prefix: fullFieldName,
+            parentCollection: targetCollection,
+            currentCollectionName,
+          })
+        }
+      })
+    } else if (ts.isArrayTypeNode(member.type)) {
+      const elementType = member.type.elementType
+      if (ts.isTypeLiteralNode(elementType)) {
+        elementType.members.forEach((nestedMember) => {
+          if (ts.isPropertySignature(nestedMember)) {
+            processFields(nestedMember, template, sourceFile, {
+              prefix: `${fullFieldName}[]`,
+              parentCollection: targetCollection,
+              currentCollectionName,
+            })
+          }
+        })
+      } else if (ts.isUnionTypeNode(elementType)) {
+        elementType.types.forEach((type) => {
+          if (ts.isTypeLiteralNode(type)) {
+            type.members.forEach((nestedMember) => {
+              if (ts.isPropertySignature(nestedMember)) {
+                processFields(nestedMember, template, sourceFile, {
+                  prefix: `${fullFieldName}[]`,
+                  parentCollection: targetCollection,
+                  currentCollectionName,
+                })
+              }
+            })
+          }
+        })
+      }
+    } else if (ts.isUnionTypeNode(member.type)) {
+      member.type.types.forEach((type) => {
+        if (ts.isTypeLiteralNode(type)) {
+          type.members.forEach((nestedMember) => {
+            if (ts.isPropertySignature(nestedMember)) {
+              processFields(nestedMember, template, sourceFile, {
+                prefix: fullFieldName,
+                parentCollection: targetCollection,
+                currentCollectionName,
+              })
+            }
+          })
+        }
+      })
+    }
+  }
+}
+
+/**
+ * Collect interfaces and blocks
+ */
+export function collectInterfacesAndBlocks(
+  sourceFile: ts.SourceFile,
+  configInfo: { collections: string[]; globals: string[] },
+): {
+  interfaceToCollection: InterfaceMapping
+  blockInterfaces: Set<string>
+} {
+  const interfaceToCollection: InterfaceMapping = {}
+  const blockInterfaces = new Set<string>()
+
+  function visit(node: ts.Node) {
+    if (ts.isInterfaceDeclaration(node)) {
+      const interfaceName = node.name.text
+
+      // Map collection interfaces
+      configInfo.collections.forEach((collName) => {
+        if (
+          interfaceName === `${collName}Config` ||
+          interfaceName === collName ||
+          interfaceName === collName.replace(/s$/, '') ||
+          interfaceName === `${collName.replace(/s$/, '')}s`
+        ) {
+          interfaceToCollection[interfaceName] = collName.toLowerCase()
+        }
+      })
+
+      // Map global interfaces
+      configInfo.globals.forEach((globalName) => {
+        if (
+          interfaceName === `${globalName}Config` ||
+          interfaceName === globalName ||
+          interfaceName === globalName.replace(/s$/, '') ||
+          interfaceName === `${globalName.replace(/s$/, '')}s`
+        ) {
+          interfaceToCollection[interfaceName] = globalName.toLowerCase()
+        }
+      })
+
+      // Collect block interfaces
+      if (
+        interfaceName.endsWith('Fields') ||
+        interfaceName.endsWith('Block') ||
+        interfaceName.includes('Layout')
+      ) {
+        blockInterfaces.add(interfaceName)
+      }
+
+      // Find layout field definitions
+      node.members.forEach((member) => {
+        if (ts.isPropertySignature(member) && member.type) {
+          if (member.name.getText() === 'layout' || member.name.getText() === 'blocks') {
+            if (ts.isArrayTypeNode(member.type)) {
+              const elementType = member.type.elementType
+              if (ts.isUnionTypeNode(elementType)) {
+                elementType.types.forEach((type) => {
+                  if (ts.isTypeReferenceNode(type)) {
+                    blockInterfaces.add(type.typeName.getText())
+                  }
+                })
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+
+  ts.forEachChild(sourceFile, visit)
+  return { interfaceToCollection, blockInterfaces }
+}
+
+/**
+ * Collect fields from all interfaces
+ */
+export function collectFields(
+  sourceFile: ts.SourceFile,
+  template: TranslationTemplate,
+  interfaceToCollection: InterfaceMapping,
+  blockInterfaces: Set<string>,
+): void {
+  function visit(node: ts.Node) {
+    if (ts.isInterfaceDeclaration(node)) {
+      const interfaceName = node.name.text
+      const collectionName = interfaceToCollection[interfaceName]
+
+      // Process block fields
+      if (blockInterfaces.has(interfaceName)) {
+        const blockName = interfaceName.replace(/(?:Fields|Block|Config)$/, '').toLowerCase()
+        if (!template.collections.pages) {
+          template.collections.pages = {
+            singular: { en: '', zh: '' },
+            plural: { en: '', zh: '' },
+            fields: {},
+          }
+        }
+
+        node.members.forEach((member) => {
+          if (ts.isPropertySignature(member)) {
+            processFields(member, template, sourceFile, {
+              prefix: blockName,
+              parentCollection: 'pages',
+              currentCollectionName: collectionName,
+            })
+          }
+        })
+      }
+
+      // Process collection fields
+      if (collectionName) {
+        if (!template.collections[collectionName]) {
+          template.collections[collectionName] = {
+            singular: { en: '', zh: '' },
+            plural: { en: '', zh: '' },
+            fields: {},
+          }
+        }
+
+        node.members.forEach((member) => {
+          if (ts.isPropertySignature(member)) {
+            processFields(member, template, sourceFile, {
+              parentCollection: collectionName,
+              currentCollectionName: collectionName,
+            })
+          }
+        })
+      }
+    }
+  }
+
+  ts.forEachChild(sourceFile, visit)
+}

--- a/scripts/generate-translations/file-generator.ts
+++ b/scripts/generate-translations/file-generator.ts
@@ -1,0 +1,208 @@
+import fs from 'fs'
+import path from 'path'
+import type { CollectionTranslation, ConfigInfo, Translation, TranslationTemplate } from './types'
+
+type TranslationValue =
+  | Translation
+  | string
+  | TranslationObject
+  | TranslationObject[]
+  | CollectionTranslation
+type TranslationObject = {
+  [key: string]: TranslationValue
+}
+
+/**
+ * Merge translations while preserving non-English content
+ */
+function mergeTranslations(
+  template: TranslationObject,
+  existing: TranslationObject,
+): TranslationObject {
+  if (!template || typeof template !== 'object') return template
+  if (!existing || typeof existing !== 'object') return template
+
+  const result: TranslationObject = {}
+
+  // Handle translation field
+  if ('en' in template && 'zh' in template) {
+    return {
+      en: template.en || existing.en || '',
+      zh: existing.zh || template.zh || '',
+    }
+  }
+
+  // Recursively merge nested objects
+  for (const key of Object.keys(template)) {
+    result[key] = mergeTranslations(
+      template[key] as TranslationObject,
+      (existing[key] || {}) as TranslationObject,
+    )
+  }
+
+  return result
+}
+
+/**
+ * Read existing translations if file exists
+ */
+function readExistingTranslations(filePath: string): TranslationObject | null {
+  try {
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, 'utf8')
+      // Extract the object from the module
+      const match = content.match(/=\s*({[\s\S]*})\s*as\s*const/)
+      if (match) {
+        return eval(`(${match[1]})`) as TranslationObject
+      }
+    }
+  } catch (error) {
+    console.warn(`Warning: Could not read existing translations from ${filePath}, error: ${error}`)
+  }
+  return null
+}
+
+/**
+ * Generate types content
+ */
+function generateTypesContent(configInfo: ConfigInfo): string {
+  return `
+// Automatically generated types file - do not modify manually
+
+// Basic translation type
+export interface Translation {
+  en: string
+  zh: string
+}
+
+// Collection specific field translation type
+export interface CollectionFields {
+  [key: string]: Translation
+}
+
+// Collection translation type
+export interface CollectionTranslation {
+  singular: Translation
+  plural: Translation
+  fields: CollectionFields
+}
+
+// All collections type
+export interface Collections {
+  ${configInfo.collections
+    .concat(configInfo.globals)
+    .map((name) => {
+      const propertyName = /[-]/.test(name) ? `'${name}'` : name.toLowerCase()
+      return `${propertyName}: CollectionTranslation`
+    })
+    .join('\n  ')}
+}
+`.trim()
+}
+
+/**
+ * Generate collections template content
+ */
+function generateCollectionsContent(template: TranslationTemplate): string {
+  return `
+import type { Collections } from './types'
+
+export const collections: Collections = ${formatTranslations(template.collections)} as const
+`.trim()
+}
+
+/**
+ * Format translation object in TypeScript style
+ */
+function formatTranslations(
+  obj: TranslationObject | { [key: string]: CollectionTranslation } | string | undefined,
+  indent = 0,
+): string {
+  if (!obj || typeof obj !== 'object') {
+    // Handle primitive values
+    return typeof obj === 'string' ? `'${obj.replace(/'/g, "\\'")}'` : String(obj || '')
+  }
+
+  const spaces = ' '.repeat(indent)
+  const innerSpaces = ' '.repeat(indent + 2)
+
+  if (Array.isArray(obj)) {
+    const items = obj.map((item) => formatTranslations(item as TranslationObject, indent + 2))
+    return `[\n${innerSpaces}${items.join(`,\n${innerSpaces}`)},\n${spaces}]`
+  }
+
+  const entries = Object.entries(obj)
+  if (entries.length === 0) return '{}'
+
+  const formattedEntries = entries.map(([key, value]) => {
+    // For keys that need quotes, use single quotes
+    const formattedKey = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key) ? key : `'${key}'`
+    return `${formattedKey}: ${formatTranslations(value as TranslationObject, indent + 2)}`
+  })
+
+  return `{\n${innerSpaces}${formattedEntries.join(`,\n${innerSpaces}`)},\n${spaces}}`
+}
+
+/**
+ * Generate all files
+ */
+export function generateFiles(
+  outputDir: string,
+  configInfo: ConfigInfo,
+  template: TranslationTemplate,
+): void {
+  // Ensure directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+
+  // Generate file content
+  const typesContent = generateTypesContent(configInfo)
+  const collectionsTemplateContent = generateCollectionsContent(template)
+
+  // Write files
+  fs.writeFileSync(path.join(outputDir, 'types.ts'), typesContent)
+  fs.writeFileSync(path.join(outputDir, 'collections.template.ts'), collectionsTemplateContent)
+
+  // Generate actual files from templates
+  generateActualFromTemplate(
+    path.join(outputDir, 'collections.template.ts'),
+    path.join(outputDir, 'collections.ts'),
+    (content) => {
+      const match = content.match(/collections:\s*Collections\s*=\s*({[\s\S]*})\s*as\s*const/)
+      return match ? eval(`(${match[1]})`) : {}
+    },
+  )
+
+  console.log('Translation files generated!')
+}
+
+/**
+ * Generate actual translation file from template
+ */
+function generateActualFromTemplate(
+  templatePath: string,
+  actualPath: string,
+  getTranslationsFromContent: (content: string) => TranslationObject,
+): void {
+  // Read template content
+  const templateContent = fs.readFileSync(templatePath, 'utf8')
+  const templateTranslations = getTranslationsFromContent(templateContent)
+
+  // Read existing translations
+  const existingTranslations = readExistingTranslations(actualPath)
+
+  // Merge translations
+  const mergedTranslations = existingTranslations
+    ? mergeTranslations(templateTranslations, existingTranslations)
+    : templateTranslations
+
+  // Generate new content by replacing translations in template
+  const newContent = templateContent.replace(
+    /=\s*({[\s\S]*})\s*as\s*const/,
+    `= ${formatTranslations(mergedTranslations)} as const`,
+  )
+
+  // Write the file
+  fs.writeFileSync(actualPath, newContent)
+}

--- a/scripts/generate-translations/index.ts
+++ b/scripts/generate-translations/index.ts
@@ -1,0 +1,52 @@
+import fs from 'fs'
+import path from 'path'
+import ts from 'typescript'
+import { getConfigInfo } from './config'
+import { collectFields, collectInterfacesAndBlocks } from './field-collector'
+import { generateFiles } from './file-generator'
+import type { TranslationTemplate } from './types'
+
+function main(): void {
+  // Get config info
+  const configPath = path.join(__dirname, '../../src/payload.config.ts')
+  const configInfo = getConfigInfo(configPath)
+
+  // Read types file
+  const typesPath = path.join(__dirname, '../../src/payload-types.ts')
+  const sourceFile = ts.createSourceFile(
+    typesPath,
+    fs.readFileSync(typesPath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  )
+
+  // Initialize translation template
+  const template: TranslationTemplate = {
+    collections: {},
+  }
+
+  // Initialize all collections as empty values
+  const allCollections = [...configInfo.collections, ...configInfo.globals]
+  allCollections.forEach((name) => {
+    template.collections[name.toLowerCase()] = {
+      singular: { en: '', zh: '' },
+      plural: { en: '', zh: '' },
+      fields: {},
+    }
+  })
+
+  // Collect interfaces and blocks
+  const { interfaceToCollection, blockInterfaces } = collectInterfacesAndBlocks(
+    sourceFile,
+    configInfo,
+  )
+
+  // Collect fields
+  collectFields(sourceFile, template, interfaceToCollection, blockInterfaces)
+
+  // Generate files
+  const outputDir = path.join(__dirname, '../../src/i18n')
+  generateFiles(outputDir, configInfo, template)
+}
+
+main()

--- a/scripts/generate-translations/types.ts
+++ b/scripts/generate-translations/types.ts
@@ -1,0 +1,45 @@
+import type { Node, PropertySignature } from 'typescript'
+
+// Basic translation type for language pairs
+export interface Translation {
+  en: string
+  zh: string
+}
+
+// Collection translation interface
+export interface CollectionTranslation {
+  singular: Translation
+  plural: Translation
+  fields: {
+    [key: string]: Translation
+  }
+}
+
+// Main translation template interface
+export interface TranslationTemplate {
+  collections: {
+    [key: string]: CollectionTranslation
+  }
+}
+
+// Configuration information interface
+export interface ConfigInfo {
+  collections: string[]
+  globals: string[]
+  blocks: Set<string>
+}
+
+// Field processing options
+export interface ProcessFieldsOptions {
+  prefix?: string
+  parentCollection?: string
+  currentCollectionName?: string
+}
+
+// Interface name to collection name mapping
+export interface InterfaceMapping {
+  [key: string]: string
+}
+
+// Re-export TypeScript types
+export type { Node, PropertySignature }

--- a/src/heros/components/Hero32/config.ts
+++ b/src/heros/components/Hero32/config.ts
@@ -1,4 +1,5 @@
 import { GroupField } from 'payload'
+import { createFieldLabel } from '@/i18n'
 import { createHeroField, heroSchemas } from '../shared/base-field'
 
 /**
@@ -41,7 +42,7 @@ export const hero32Fields: GroupField = {
           minRows: 15,
           maxRows: 15,
           admin: {
-            description: 'Integration images (exactly 15)',
+            description: createFieldLabel('hero32.hero.integrations', 'pages'),
           },
         },
       ],

--- a/src/heros/components/shared/base-field.ts
+++ b/src/heros/components/shared/base-field.ts
@@ -1,6 +1,7 @@
 import { GroupField } from 'payload'
 import { z } from 'zod'
 import { link } from '@/fields/link'
+import { createFieldLabel } from '@/i18n'
 import { createFieldGroup, FieldGroupOptions } from '@/utilities/createFieldGroup'
 
 /**
@@ -45,6 +46,7 @@ export const heroSchemas = {
 const basicFields = {
   title: {
     name: 'title',
+    label: createFieldLabel('title'),
     type: 'text',
     required: true,
     admin: {
@@ -53,9 +55,13 @@ const basicFields = {
   },
   subtitle: {
     name: 'subtitle',
+    label: createFieldLabel('subtitle'),
     type: 'textarea',
     admin: {
-      description: 'Subtitle text',
+      description: {
+        en: 'Subtitle text',
+        zh: '副标题',
+      },
     },
   },
   trustText: {
@@ -81,6 +87,7 @@ const basicFields = {
 const mediaFields = {
   image: {
     name: 'image',
+    label: createFieldLabel('image'),
     type: 'upload',
     relationTo: 'media',
     required: true,
@@ -112,6 +119,7 @@ const featureFields = {
   },
   title: {
     name: 'title',
+    label: createFieldLabel('title'),
     type: 'text',
     required: true,
     admin: {
@@ -183,6 +191,7 @@ const partnerFields = {
 const miscFields = {
   badge: {
     name: 'badge',
+    label: createFieldLabel('badge'),
     type: 'text',
     admin: {
       description: 'Badge text displayed above title',

--- a/src/i18n/AUTOGEN_I18N.md
+++ b/src/i18n/AUTOGEN_I18N.md
@@ -1,0 +1,125 @@
+# Workflow
+
+1. Create/Modify Fields
+
+   - Use English labels when creating collections, fields, or blocks
+   - Ensure labels are clear and descriptive
+   - Add JSDoc comments for more detailed field descriptions
+
+2. Generate Type Files
+
+   ```bash
+   bun generate:types
+   ```
+
+   - This generates payload-types.ts
+   - Contains type definitions for all collections and fields
+   - The translation script scans this file to collect translatable content
+
+3. Generate Translation Files
+
+   ```bash
+   bun generate:translations
+   ```
+
+   - This generates the following 5 files:
+
+     ```bash
+     src/i18n
+     ├── collections.template.ts # Template file for collection translations
+     ├── collections.ts         # Actual collection translations (includes translated content)
+     ├── common-fields.template.ts # Template file for common field translations
+     ├── common-fields.ts       # Actual common field translations (includes translated content)
+     └── types.ts              # TypeScript type definitions for translations
+     ```
+
+   - Template files (\*.template.ts) contain all English content that needs translation
+   - Actual translation files (without .template) store the translated content
+
+4. Translation Workflow
+
+   - Check .template.ts files for new content
+   - Add translations in corresponding actual translation files
+   - Don't modify .template.ts files directly as they are regenerated each time
+   - Existing translations are preserved and won't be overwritten
+
+5. Translation Files Overview
+
+   - common-fields.ts: Stores translations for fields used across multiple collections
+   - collections.ts: Stores collection-specific field translations
+   - Each translation entry contains en (English) and zh (Chinese) fields
+
+6. Using Translations
+
+   ```typescript
+   import { createFieldLabel } from '@/i18n'
+
+   // Basic Collection Config
+   export const PostsConfig = {
+     label: createFieldLabel('posts', undefined, 'Posts'),
+     fields: [
+       {
+         name: 'title',
+         type: 'text',
+         required: true,
+         label: createFieldLabel('title'),
+       },
+       {
+         name: 'heroImage',
+         type: 'upload',
+         relationTo: 'media',
+         label: createFieldLabel('heroImage', 'posts', 'Hero Image'),
+       },
+     ],
+   }
+
+   // Table Columns
+   export const tableColumns = [
+     {
+       header: createFieldLabel('title'),
+       accessorKey: 'title',
+     },
+   ]
+
+   // Validation Messages
+   export const validationMessages = {
+     required: (fieldName: string) => {
+       const label = toTranslation(createFieldLabel(fieldName))
+       return {
+         en: `${label.en} is required`,
+         zh: `${label.zh}是必填项`,
+       }
+     },
+   }
+   ```
+
+# Important Notes
+
+1. Template Files (\*.template.ts)
+
+   - These files are regenerated each time generate:translations is run
+   - Do not modify them manually as changes will be overwritten
+   - Used to track the latest content requiring translation
+
+2. Actual Translation Files
+
+   - collections.ts and common-fields.ts store the actual translations
+   - Existing translations are preserved
+   - Only new English content is updated
+   - Translations for deleted fields are automatically cleaned up
+
+3. Type Safety
+
+   - types.ts provides complete type definitions
+   - All translation operations are type-safe
+   - TypeScript type checking ensures translation integrity
+
+4. Best Practices
+
+   - Run generate:translations regularly to sync latest translation needs
+   - Provide clear English descriptions when adding new fields
+   - Use JSDoc comments for detailed field descriptions
+   - Keep translation files clean by removing unused translations
+   - Backup files before generation to prevent data loss
+   - Use consistent naming conventions for fields
+   - Test translations in both languages before deployment

--- a/src/i18n/AUTOGEN_I18N.zh-CN.md
+++ b/src/i18n/AUTOGEN_I18N.zh-CN.md
@@ -1,0 +1,122 @@
+# 工作流程
+
+1. 创建/修改字段
+
+   - 在创建collection、field或block时，使用英文填写label字段
+   - 确保使用清晰、描述性的英文标签
+   - 可以添加JSDoc注释来提供更详细的字段描述
+
+2. 生成类型文件
+
+   ```bash
+   bun generate:types
+   ```
+
+   - 这会生成payload-types.ts
+   - 该文件包含所有collection和field的类型定义
+   - 翻译脚本会扫描这个文件来收集需要翻译的内容
+
+3. 生成翻译文件
+
+   ```bash
+   bun generate:translations
+   ```
+
+   - 这会生成以下的5个文件
+
+     ```bash
+     src/i18n
+     ├── collections.template.ts # 集合相关的翻译模板文件
+     ├── collections.ts # 实际的集合翻译文件（包含已翻译内容）
+     ├── common-fields.template.ts # 公共字段的翻译模板文件
+     ├── common-fields.ts # 实际的公共字段翻译文件（包含已翻译内容）
+     └── types.ts # 翻译相关的TypeScript类型定义
+     ```
+
+   - template文件（\*.template.ts）包含所有需要翻译的英文内容
+   - 实际翻译文件（不带.template）保存了已翻译的内容
+
+4. 翻译工作流
+
+   - 检查.template.ts文件中的新增内容
+   - 在对应的实际翻译文件中添加翻译
+   - 不要直接修改.template.ts文件，它们会在每次运行脚本时重新生成
+   - 已有的中文翻译会被保留，不会被覆盖
+
+5. 翻译文件说明
+
+   - common-fields.ts：存储在多个collection中重复使用的字段翻译
+   - collections.ts：存储每个collection特有的字段翻译
+   - 每个翻译条目都包含en（英文）和zh（中文）两个字段
+
+6. 使用翻译
+
+```typescript
+import { createFieldLabel } from '@/i18n'
+
+// Basic Collection Config
+export const PostsConfig = {
+  label: createFieldLabel('posts', undefined, 'Posts'),
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      label: createFieldLabel('title'),
+    },
+    {
+      name: 'heroImage',
+      type: 'upload',
+      relationTo: 'media',
+      label: createFieldLabel('heroImage', 'posts', 'Hero Image'),
+    },
+  ],
+}
+
+// Table Columns
+export const tableColumns = [
+  {
+    header: createFieldLabel('title'),
+    accessorKey: 'title',
+  },
+]
+
+// Validation Messages
+export const validationMessages = {
+  required: (fieldName: string) => {
+    const label = toTranslation(createFieldLabel(fieldName))
+    return {
+      en: `${label.en} is required`,
+      zh: `${label.zh}是必填项`,
+    }
+  },
+}
+```
+
+# 注意事项
+
+1. 模板文件（\*.template.ts）
+
+   - 这些文件会在每次运行generate:translations时重新生成
+   - 不要手动修改这些文件，因为修改会被覆盖
+   - 用于跟踪需要翻译的最新内容
+
+2. 实际翻译文件
+
+   - collections.ts和common-fields.ts保存实际的翻译内容
+   - 这些文件会保留已有的中文翻译
+   - 只有新增的英文内容会被更新
+   - 删除的字段对应的翻译会被自动清理
+
+3. 类型安全
+
+   - types.ts提供了完整的类型定义
+   - 所有的翻译操作都是类型安全的
+   - 使用TypeScript的类型检查来确保翻译的完整性
+
+4. 最佳实践
+   - 定期运行generate:translations来同步最新的翻译需求
+   - 在添加新字段时，提供清晰的英文描述
+   - 使用JSDoc注释来提供更详细的字段说明
+   - 保持翻译文件的整洁，删除不再使用的翻译
+   - 生成之前，为了防止丢失，可以先备份一下

--- a/src/i18n/collections.template.ts
+++ b/src/i18n/collections.template.ts
@@ -1,0 +1,599 @@
+import type { Collections } from './types'
+
+export const collections: Collections = {
+  pages: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      layout: {
+        en: 'Layout',
+        zh: '',
+      },
+      'hero32.hero.integrations': {
+        en: 'Integration images (exactly 15)',
+        zh: '',
+      },
+      'hero6.hero.secondaryImage': {
+        en: 'Secondary image with button',
+        zh: '',
+      },
+      'hero3.hero.review': {
+        en: 'Review section configuration',
+        zh: '',
+      },
+      'hero115.hero.trustText': {
+        en: 'Text showing trust metrics (e.g., "Trusted by X businesses")',
+        zh: '',
+      },
+      'cta.cta-1': {
+        en: 'Cta-1',
+        zh: '',
+      },
+      'cta.cta-3': {
+        en: 'Cta-3',
+        zh: '',
+      },
+      'cta.cta-4': {
+        en: 'Cta-4',
+        zh: '',
+      },
+      'cta.cta-5': {
+        en: 'Cta-5',
+        zh: '',
+      },
+      'cta.cta-7': {
+        en: 'Cta-7',
+        zh: '',
+      },
+      'cta.cta-10': {
+        en: 'Cta-10',
+        zh: '',
+      },
+      'cta.cta-11': {
+        en: 'Cta-11',
+        zh: '',
+      },
+      'cta.cta-15': {
+        en: 'Cta-15',
+        zh: '',
+      },
+      'cta.cta-16': {
+        en: 'Cta-16',
+        zh: '',
+      },
+      'cta.cta-17': {
+        en: 'Cta-17',
+        zh: '',
+      },
+      'cta3.cta.buttonLinks': {
+        en: 'CTA buttons',
+        zh: '',
+      },
+      'cta3.cta.listLinks': {
+        en: 'List of links',
+        zh: '',
+      },
+      'content.columns': {
+        en: 'Columns',
+        zh: '',
+      },
+      'archive.populateBy': {
+        en: 'Populate by',
+        zh: '',
+      },
+      'archive.relationTo': {
+        en: 'Relation to',
+        zh: '',
+      },
+      'archive.limit': {
+        en: 'Limit',
+        zh: '',
+      },
+      'archive.selectedDocs': {
+        en: 'Selected docs',
+        zh: '',
+      },
+      'form.enableIntro': {
+        en: 'Enable intro',
+        zh: '',
+      },
+      'gallery.gallery-1': {
+        en: 'Gallery-1',
+        zh: '',
+      },
+      'gallery.gallery-3': {
+        en: 'Gallery-3',
+        zh: '',
+      },
+      'gallery.gallery-4': {
+        en: 'Gallery-4',
+        zh: '',
+      },
+      'gallery.gallery-5': {
+        en: 'Gallery-5',
+        zh: '',
+      },
+      'gallery.gallery-6': {
+        en: 'Gallery-6',
+        zh: '',
+      },
+      'gallery.gallery-9': {
+        en: 'Gallery-9',
+        zh: '',
+      },
+      'gallery6.gallery.cards': {
+        en: 'Gallery cards (3-6)',
+        zh: '',
+      },
+      'feature.feature-1': {
+        en: 'Feature-1',
+        zh: '',
+      },
+      'feature.feature-2': {
+        en: 'Feature-2',
+        zh: '',
+      },
+      'feature.feature-3': {
+        en: 'Feature-3',
+        zh: '',
+      },
+      'feature.feature-5': {
+        en: 'Feature-5',
+        zh: '',
+      },
+      'feature.feature-6': {
+        en: 'Feature-6',
+        zh: '',
+      },
+      'feature.feature-7': {
+        en: 'Feature-7',
+        zh: '',
+      },
+      'feature.feature-10': {
+        en: 'Feature-10',
+        zh: '',
+      },
+      'feature.feature-11': {
+        en: 'Feature-11',
+        zh: '',
+      },
+      'feature.feature-13': {
+        en: 'Feature-13',
+        zh: '',
+      },
+      'feature.feature-14': {
+        en: 'Feature-14',
+        zh: '',
+      },
+      'feature.feature-15': {
+        en: 'Feature-15',
+        zh: '',
+      },
+      'feature5.feature.testimonial.name': {
+        en: 'Author name',
+        zh: '',
+      },
+      'feature5.feature.testimonial.role': {
+        en: 'Author role or position',
+        zh: '',
+      },
+      'feature5.feature.testimonial.company': {
+        en: 'Author company',
+        zh: '',
+      },
+      'testimonial.testimonial-4': {
+        en: 'Testimonial-4',
+        zh: '',
+      },
+      'testimonial.testimonial-6': {
+        en: 'Testimonial-6',
+        zh: '',
+      },
+      'testimonial.testimonial-7': {
+        en: 'Testimonial-7',
+        zh: '',
+      },
+      'testimonial.testimonial-12': {
+        en: 'Testimonial-12',
+        zh: '',
+      },
+      'testimonial.testimonial-14': {
+        en: 'Testimonial-14',
+        zh: '',
+      },
+      'testimonial.testimonial-15': {
+        en: 'Testimonial-15',
+        zh: '',
+      },
+      'testimonial.testimonial-16': {
+        en: 'Testimonial-16',
+        zh: '',
+      },
+      'testimonial.testimonial-17': {
+        en: 'Testimonial-17',
+        zh: '',
+      },
+      'testimonial.testimonial-18': {
+        en: 'Testimonial-18',
+        zh: '',
+      },
+      'testimonial.testimonial-19': {
+        en: 'Testimonial-19',
+        zh: '',
+      },
+      'testimonial4.featuredImage': {
+        en: 'Featured image displayed in the left column',
+        zh: '',
+      },
+      'testimonial15.companySection': {
+        en: 'Company section configuration',
+        zh: '',
+      },
+      'testimonial15.companySection.text': {
+        en: 'Text displayed above company logos',
+        zh: '',
+      },
+      'testimonial19.viewAll': {
+        en: 'View all testimonials link',
+        zh: '',
+      },
+      'contact.contact-1': {
+        en: 'Contact-1',
+        zh: '',
+      },
+      'contact.contact-2': {
+        en: 'Contact-2',
+        zh: '',
+      },
+      'contact.contact-3': {
+        en: 'Contact-3',
+        zh: '',
+      },
+      'contact.contact-4': {
+        en: 'Contact-4',
+        zh: '',
+      },
+      'contact.contact-5': {
+        en: 'Contact-5',
+        zh: '',
+      },
+      'contact.contact-6': {
+        en: 'Contact-6',
+        zh: '',
+      },
+      'contact.contact-7': {
+        en: 'Contact-7',
+        zh: '',
+      },
+      'contact.contact-8': {
+        en: 'Contact-8',
+        zh: '',
+      },
+      'contact4.contact.locationList': {
+        en: 'Location list',
+        zh: '',
+      },
+      'contact4.contact.locationList.locations': {
+        en: 'Location carousel',
+        zh: '',
+      },
+      'team.team-1': {
+        en: 'Team-1',
+        zh: '',
+      },
+      'team.team-2': {
+        en: 'Team-2',
+        zh: '',
+      },
+      'team.team-3': {
+        en: 'Team-3',
+        zh: '',
+      },
+      'team.team-5': {
+        en: 'Team-5',
+        zh: '',
+      },
+      'team.team-6': {
+        en: 'Team-6',
+        zh: '',
+      },
+      'faq.faq-1': {
+        en: 'Faq-1',
+        zh: '',
+      },
+      'faq.faq-2': {
+        en: 'Faq-2',
+        zh: '',
+      },
+      'faq.faq-3': {
+        en: 'Faq-3',
+        zh: '',
+      },
+      'faq.faq-4': {
+        en: 'Faq-4',
+        zh: '',
+      },
+      'faq.faq-5': {
+        en: 'Faq-5',
+        zh: '',
+      },
+      'faq.faq-6': {
+        en: 'Faq-6',
+        zh: '',
+      },
+      'logos.logos-1': {
+        en: 'Logos-1',
+        zh: '',
+      },
+      'logos.logos-2': {
+        en: 'Logos-2',
+        zh: '',
+      },
+      'logos.logos-3': {
+        en: 'Logos-3',
+        zh: '',
+      },
+      'logos.logos-8': {
+        en: 'Logos-8',
+        zh: '',
+      },
+      'footer4.footer.newsletter': {
+        en: 'Newsletter',
+        zh: '',
+      },
+      'footer5.footer.appLinks': {
+        en: 'App links',
+        zh: '',
+      },
+      'code.language': {
+        en: 'Language',
+        zh: '',
+      },
+      'code.code': {
+        en: 'Code',
+        zh: '',
+      },
+    },
+  },
+  posts: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      heroImage: {
+        en: 'Hero image',
+        zh: '',
+      },
+      relatedPosts: {
+        en: 'Related posts',
+        zh: '',
+      },
+      authors: {
+        en: 'Authors',
+        zh: '',
+      },
+      populatedAuthors: {
+        en: 'Populated authors',
+        zh: '',
+      },
+    },
+  },
+  media: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      alt: {
+        en: 'Alt',
+        zh: '',
+      },
+      caption: {
+        en: 'Caption',
+        zh: '',
+      },
+      thumbnailURL: {
+        en: 'Thumbnail u r l',
+        zh: '',
+      },
+      focalX: {
+        en: 'Focal x',
+        zh: '',
+      },
+      focalY: {
+        en: 'Focal y',
+        zh: '',
+      },
+      sizes: {
+        en: 'Sizes',
+        zh: '',
+      },
+      'sizes.thumbnail': {
+        en: 'Thumbnail',
+        zh: '',
+      },
+      'sizes.square': {
+        en: 'Square',
+        zh: '',
+      },
+      'sizes.small': {
+        en: 'Small',
+        zh: '',
+      },
+      'sizes.medium': {
+        en: 'Medium',
+        zh: '',
+      },
+      'sizes.large': {
+        en: 'Large',
+        zh: '',
+      },
+      'sizes.xlarge': {
+        en: 'Xlarge',
+        zh: '',
+      },
+      'sizes.og': {
+        en: 'Og',
+        zh: '',
+      },
+    },
+  },
+  categories: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {},
+  },
+  users: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      roles: {
+        en: 'Roles',
+        zh: '',
+      },
+      username: {
+        en: 'Username',
+        zh: '',
+      },
+      tenants: {
+        en: 'Tenants',
+        zh: '',
+      },
+      email: {
+        en: 'Email',
+        zh: '',
+      },
+      resetPasswordToken: {
+        en: 'Reset password token',
+        zh: '',
+      },
+      resetPasswordExpiration: {
+        en: 'Reset password expiration',
+        zh: '',
+      },
+      salt: {
+        en: 'Salt',
+        zh: '',
+      },
+      hash: {
+        en: 'Hash',
+        zh: '',
+      },
+      loginAttempts: {
+        en: 'Login attempts',
+        zh: '',
+      },
+      lockUntil: {
+        en: 'Lock until',
+        zh: '',
+      },
+      password: {
+        en: 'Password',
+        zh: '',
+      },
+    },
+  },
+  header: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      'header-1': {
+        en: 'Header-1',
+        zh: '',
+      },
+      'header-3': {
+        en: 'Header-3',
+        zh: '',
+      },
+      'header-5': {
+        en: 'Header-5',
+        zh: '',
+      },
+    },
+  },
+  footer: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      'footer-1': {
+        en: 'Footer-1',
+        zh: '',
+      },
+      'footer-2': {
+        en: 'Footer-2',
+        zh: '',
+      },
+      'footer-3': {
+        en: 'Footer-3',
+        zh: '',
+      },
+      'footer-4': {
+        en: 'Footer-4',
+        zh: '',
+      },
+      'footer-5': {
+        en: 'Footer-5',
+        zh: '',
+      },
+      'footer-6': {
+        en: 'Footer-6',
+        zh: '',
+      },
+      'footer-7': {
+        en: 'Footer-7',
+        zh: '',
+      },
+      'footer-8': {
+        en: 'Footer-8',
+        zh: '',
+      },
+      'footer-9': {
+        en: 'Footer-9',
+        zh: '',
+      },
+      'footer-10': {
+        en: 'Footer-10',
+        zh: '',
+      },
+    },
+  },
+} as const

--- a/src/i18n/collections.ts
+++ b/src/i18n/collections.ts
@@ -1,0 +1,599 @@
+import type { Collections } from './types'
+
+export const collections: Collections = {
+  pages: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      layout: {
+        en: 'Layout',
+        zh: '',
+      },
+      'hero32.hero.integrations': {
+        en: 'Integration images (exactly 15)',
+        zh: '集成图像（正好15张）',
+      },
+      'hero6.hero.secondaryImage': {
+        en: 'Secondary image with button',
+        zh: '带有按钮的次要图像',
+      },
+      'hero3.hero.review': {
+        en: 'Review section configuration',
+        zh: '评论部分配置',
+      },
+      'hero115.hero.trustText': {
+        en: 'Text showing trust metrics (e.g., "Trusted by X businesses")',
+        zh: '显示信任指标的文本（例如：“由X家企业信任”）',
+      },
+      'cta.cta-1': {
+        en: 'Cta-1',
+        zh: '',
+      },
+      'cta.cta-3': {
+        en: 'Cta-3',
+        zh: '',
+      },
+      'cta.cta-4': {
+        en: 'Cta-4',
+        zh: '',
+      },
+      'cta.cta-5': {
+        en: 'Cta-5',
+        zh: '',
+      },
+      'cta.cta-7': {
+        en: 'Cta-7',
+        zh: '',
+      },
+      'cta.cta-10': {
+        en: 'Cta-10',
+        zh: '',
+      },
+      'cta.cta-11': {
+        en: 'Cta-11',
+        zh: '',
+      },
+      'cta.cta-15': {
+        en: 'Cta-15',
+        zh: '',
+      },
+      'cta.cta-16': {
+        en: 'Cta-16',
+        zh: '',
+      },
+      'cta.cta-17': {
+        en: 'Cta-17',
+        zh: '',
+      },
+      'cta3.cta.buttonLinks': {
+        en: 'CTA buttons',
+        zh: '',
+      },
+      'cta3.cta.listLinks': {
+        en: 'List of links',
+        zh: '',
+      },
+      'content.columns': {
+        en: 'Columns',
+        zh: '',
+      },
+      'archive.populateBy': {
+        en: 'Populate by',
+        zh: '',
+      },
+      'archive.relationTo': {
+        en: 'Relation to',
+        zh: '',
+      },
+      'archive.limit': {
+        en: 'Limit',
+        zh: '',
+      },
+      'archive.selectedDocs': {
+        en: 'Selected docs',
+        zh: '',
+      },
+      'form.enableIntro': {
+        en: 'Enable intro',
+        zh: '',
+      },
+      'gallery.gallery-1': {
+        en: 'Gallery-1',
+        zh: '',
+      },
+      'gallery.gallery-3': {
+        en: 'Gallery-3',
+        zh: '',
+      },
+      'gallery.gallery-4': {
+        en: 'Gallery-4',
+        zh: '',
+      },
+      'gallery.gallery-5': {
+        en: 'Gallery-5',
+        zh: '',
+      },
+      'gallery.gallery-6': {
+        en: 'Gallery-6',
+        zh: '',
+      },
+      'gallery.gallery-9': {
+        en: 'Gallery-9',
+        zh: '',
+      },
+      'gallery6.gallery.cards': {
+        en: 'Gallery cards (3-6)',
+        zh: '',
+      },
+      'feature.feature-1': {
+        en: 'Feature-1',
+        zh: '',
+      },
+      'feature.feature-2': {
+        en: 'Feature-2',
+        zh: '',
+      },
+      'feature.feature-3': {
+        en: 'Feature-3',
+        zh: '',
+      },
+      'feature.feature-5': {
+        en: 'Feature-5',
+        zh: '',
+      },
+      'feature.feature-6': {
+        en: 'Feature-6',
+        zh: '',
+      },
+      'feature.feature-7': {
+        en: 'Feature-7',
+        zh: '',
+      },
+      'feature.feature-10': {
+        en: 'Feature-10',
+        zh: '',
+      },
+      'feature.feature-11': {
+        en: 'Feature-11',
+        zh: '',
+      },
+      'feature.feature-13': {
+        en: 'Feature-13',
+        zh: '',
+      },
+      'feature.feature-14': {
+        en: 'Feature-14',
+        zh: '',
+      },
+      'feature.feature-15': {
+        en: 'Feature-15',
+        zh: '',
+      },
+      'feature5.feature.testimonial.name': {
+        en: 'Author name',
+        zh: '',
+      },
+      'feature5.feature.testimonial.role': {
+        en: 'Author role or position',
+        zh: '',
+      },
+      'feature5.feature.testimonial.company': {
+        en: 'Author company',
+        zh: '',
+      },
+      'testimonial.testimonial-4': {
+        en: 'Testimonial-4',
+        zh: '',
+      },
+      'testimonial.testimonial-6': {
+        en: 'Testimonial-6',
+        zh: '',
+      },
+      'testimonial.testimonial-7': {
+        en: 'Testimonial-7',
+        zh: '',
+      },
+      'testimonial.testimonial-12': {
+        en: 'Testimonial-12',
+        zh: '',
+      },
+      'testimonial.testimonial-14': {
+        en: 'Testimonial-14',
+        zh: '',
+      },
+      'testimonial.testimonial-15': {
+        en: 'Testimonial-15',
+        zh: '',
+      },
+      'testimonial.testimonial-16': {
+        en: 'Testimonial-16',
+        zh: '',
+      },
+      'testimonial.testimonial-17': {
+        en: 'Testimonial-17',
+        zh: '',
+      },
+      'testimonial.testimonial-18': {
+        en: 'Testimonial-18',
+        zh: '',
+      },
+      'testimonial.testimonial-19': {
+        en: 'Testimonial-19',
+        zh: '',
+      },
+      'testimonial4.featuredImage': {
+        en: 'Featured image displayed in the left column',
+        zh: '',
+      },
+      'testimonial15.companySection': {
+        en: 'Company section configuration',
+        zh: '',
+      },
+      'testimonial15.companySection.text': {
+        en: 'Text displayed above company logos',
+        zh: '',
+      },
+      'testimonial19.viewAll': {
+        en: 'View all testimonials link',
+        zh: '',
+      },
+      'contact.contact-1': {
+        en: 'Contact-1',
+        zh: '',
+      },
+      'contact.contact-2': {
+        en: 'Contact-2',
+        zh: '',
+      },
+      'contact.contact-3': {
+        en: 'Contact-3',
+        zh: '',
+      },
+      'contact.contact-4': {
+        en: 'Contact-4',
+        zh: '',
+      },
+      'contact.contact-5': {
+        en: 'Contact-5',
+        zh: '',
+      },
+      'contact.contact-6': {
+        en: 'Contact-6',
+        zh: '',
+      },
+      'contact.contact-7': {
+        en: 'Contact-7',
+        zh: '',
+      },
+      'contact.contact-8': {
+        en: 'Contact-8',
+        zh: '',
+      },
+      'contact4.contact.locationList': {
+        en: 'Location list',
+        zh: '',
+      },
+      'contact4.contact.locationList.locations': {
+        en: 'Location carousel',
+        zh: '',
+      },
+      'team.team-1': {
+        en: 'Team-1',
+        zh: '',
+      },
+      'team.team-2': {
+        en: 'Team-2',
+        zh: '',
+      },
+      'team.team-3': {
+        en: 'Team-3',
+        zh: '',
+      },
+      'team.team-5': {
+        en: 'Team-5',
+        zh: '',
+      },
+      'team.team-6': {
+        en: 'Team-6',
+        zh: '',
+      },
+      'faq.faq-1': {
+        en: 'Faq-1',
+        zh: '',
+      },
+      'faq.faq-2': {
+        en: 'Faq-2',
+        zh: '',
+      },
+      'faq.faq-3': {
+        en: 'Faq-3',
+        zh: '',
+      },
+      'faq.faq-4': {
+        en: 'Faq-4',
+        zh: '',
+      },
+      'faq.faq-5': {
+        en: 'Faq-5',
+        zh: '',
+      },
+      'faq.faq-6': {
+        en: 'Faq-6',
+        zh: '',
+      },
+      'logos.logos-1': {
+        en: 'Logos-1',
+        zh: '',
+      },
+      'logos.logos-2': {
+        en: 'Logos-2',
+        zh: '',
+      },
+      'logos.logos-3': {
+        en: 'Logos-3',
+        zh: '',
+      },
+      'logos.logos-8': {
+        en: 'Logos-8',
+        zh: '',
+      },
+      'footer4.footer.newsletter': {
+        en: 'Newsletter',
+        zh: '',
+      },
+      'footer5.footer.appLinks': {
+        en: 'App links',
+        zh: '',
+      },
+      'code.language': {
+        en: 'Language',
+        zh: '',
+      },
+      'code.code': {
+        en: 'Code',
+        zh: '',
+      },
+    },
+  },
+  posts: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      heroImage: {
+        en: 'Hero image',
+        zh: '',
+      },
+      relatedPosts: {
+        en: 'Related posts',
+        zh: '',
+      },
+      authors: {
+        en: 'Authors',
+        zh: '',
+      },
+      populatedAuthors: {
+        en: 'Populated authors',
+        zh: '',
+      },
+    },
+  },
+  media: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      alt: {
+        en: 'Alt',
+        zh: '',
+      },
+      caption: {
+        en: 'Caption',
+        zh: '',
+      },
+      thumbnailURL: {
+        en: 'Thumbnail u r l',
+        zh: '',
+      },
+      focalX: {
+        en: 'Focal x',
+        zh: '',
+      },
+      focalY: {
+        en: 'Focal y',
+        zh: '',
+      },
+      sizes: {
+        en: 'Sizes',
+        zh: '',
+      },
+      'sizes.thumbnail': {
+        en: 'Thumbnail',
+        zh: '',
+      },
+      'sizes.square': {
+        en: 'Square',
+        zh: '',
+      },
+      'sizes.small': {
+        en: 'Small',
+        zh: '',
+      },
+      'sizes.medium': {
+        en: 'Medium',
+        zh: '',
+      },
+      'sizes.large': {
+        en: 'Large',
+        zh: '',
+      },
+      'sizes.xlarge': {
+        en: 'Xlarge',
+        zh: '',
+      },
+      'sizes.og': {
+        en: 'Og',
+        zh: '',
+      },
+    },
+  },
+  categories: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {},
+  },
+  users: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      roles: {
+        en: 'Roles',
+        zh: '',
+      },
+      username: {
+        en: 'Username',
+        zh: '',
+      },
+      tenants: {
+        en: 'Tenants',
+        zh: '',
+      },
+      email: {
+        en: 'Email',
+        zh: '',
+      },
+      resetPasswordToken: {
+        en: 'Reset password token',
+        zh: '',
+      },
+      resetPasswordExpiration: {
+        en: 'Reset password expiration',
+        zh: '',
+      },
+      salt: {
+        en: 'Salt',
+        zh: '',
+      },
+      hash: {
+        en: 'Hash',
+        zh: '',
+      },
+      loginAttempts: {
+        en: 'Login attempts',
+        zh: '',
+      },
+      lockUntil: {
+        en: 'Lock until',
+        zh: '',
+      },
+      password: {
+        en: 'Password',
+        zh: '',
+      },
+    },
+  },
+  header: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      'header-1': {
+        en: 'Header-1',
+        zh: '',
+      },
+      'header-3': {
+        en: 'Header-3',
+        zh: '',
+      },
+      'header-5': {
+        en: 'Header-5',
+        zh: '',
+      },
+    },
+  },
+  footer: {
+    singular: {
+      en: '',
+      zh: '',
+    },
+    plural: {
+      en: '',
+      zh: '',
+    },
+    fields: {
+      'footer-1': {
+        en: 'Footer-1',
+        zh: '',
+      },
+      'footer-2': {
+        en: 'Footer-2',
+        zh: '',
+      },
+      'footer-3': {
+        en: 'Footer-3',
+        zh: '',
+      },
+      'footer-4': {
+        en: 'Footer-4',
+        zh: '',
+      },
+      'footer-5': {
+        en: 'Footer-5',
+        zh: '',
+      },
+      'footer-6': {
+        en: 'Footer-6',
+        zh: '',
+      },
+      'footer-7': {
+        en: 'Footer-7',
+        zh: '',
+      },
+      'footer-8': {
+        en: 'Footer-8',
+        zh: '',
+      },
+      'footer-9': {
+        en: 'Footer-9',
+        zh: '',
+      },
+      'footer-10': {
+        en: 'Footer-10',
+        zh: '',
+      },
+    },
+  },
+} as const

--- a/src/i18n/common-fields.template.ts
+++ b/src/i18n/common-fields.template.ts
@@ -1,0 +1,353 @@
+import type { CommonFields } from './types'
+
+// Common fields translation
+export const commonFields: CommonFields = {
+  tenant: {
+    en: 'Tenant',
+    zh: '',
+  },
+  title: {
+    en: 'Title',
+    zh: '',
+  },
+  hero: {
+    en: 'Hero',
+    zh: '',
+  },
+  meta: {
+    en: 'Meta',
+    zh: '',
+  },
+  image: {
+    en: 'Maximum upload file size: 12MB. Recommended file size for images is <500KB.',
+    zh: '',
+  },
+  description: {
+    en: 'Description',
+    zh: '',
+  },
+  publishedAt: {
+    en: 'Published at',
+    zh: '',
+  },
+  slug: {
+    en: 'Slug',
+    zh: '',
+  },
+  slugLock: {
+    en: 'Slug lock',
+    zh: '',
+  },
+  _status: {
+    en: '_status',
+    zh: '',
+  },
+  subtitle: {
+    en: 'Subtitle text',
+    zh: '',
+  },
+  badge: {
+    en: 'Badge text displayed above title',
+    zh: '',
+  },
+  links: {
+    en: 'Hero buttons',
+    zh: '',
+  },
+  link: {
+    en: 'Hero button',
+    zh: '',
+  },
+  type: {
+    en: 'Type',
+    zh: '',
+  },
+  newTab: {
+    en: 'New tab',
+    zh: '',
+  },
+  reference: {
+    en: 'Reference',
+    zh: '',
+  },
+  url: {
+    en: 'Url',
+    zh: '',
+  },
+  label: {
+    en: 'Label',
+    zh: '',
+  },
+  prefixIcon: {
+    en: 'Optional: Lucide icon name for prefix (e.g., "ArrowLeft")',
+    zh: '',
+  },
+  suffixIcon: {
+    en: 'Optional: Lucide icon name for suffix (e.g., "ArrowRight")',
+    zh: '',
+  },
+  appearance: {
+    en: 'Choose how the link should be rendered.',
+    zh: '',
+  },
+  rating: {
+    en: 'Rating information',
+    zh: '',
+  },
+  rate: {
+    en: 'Rating value (0-5)',
+    zh: '',
+  },
+  count: {
+    en: 'Number of ratings',
+    zh: '',
+  },
+  avatars: {
+    en: 'User avatars (3-5)',
+    zh: '',
+  },
+  logo: {
+    en: 'Partner logo image',
+    zh: '',
+  },
+  partners: {
+    en: 'Partner logos (1-6)',
+    zh: '',
+  },
+  features: {
+    en: 'Feature list (exactly 4 items)',
+    zh: '',
+  },
+  media: {
+    en: 'Hero media',
+    zh: '',
+  },
+  style: {
+    en: 'Style',
+    zh: '',
+  },
+  blockName: {
+    en: 'Block name',
+    zh: '',
+  },
+  cta: {
+    en: 'CTA section fields',
+    zh: '',
+  },
+  icon: {
+    en: 'Optional: Lucide icon name (e.g., CheckCircle)',
+    zh: '',
+  },
+  lists: {
+    en: 'List with icons',
+    zh: '',
+  },
+  heading: {
+    en: 'The heading text above the title',
+    zh: '',
+  },
+  introContent: {
+    en: 'Intro content',
+    zh: '',
+  },
+  root: {
+    en: 'Root',
+    zh: '',
+  },
+  children: {
+    en: 'Children',
+    zh: '',
+  },
+  version: {
+    en: 'Version',
+    zh: '',
+  },
+  direction: {
+    en: 'Direction',
+    zh: '',
+  },
+  format: {
+    en: 'Format',
+    zh: '',
+  },
+  indent: {
+    en: 'Indent',
+    zh: '',
+  },
+  categories: {
+    en: 'Categories',
+    zh: '',
+  },
+  form: {
+    en: 'Form',
+    zh: '',
+  },
+  gallery: {
+    en: 'Gallery section fields',
+    zh: '',
+  },
+  items: {
+    en: 'Gallery items (1-6)',
+    zh: '',
+  },
+  sections: {
+    en: 'Gallery sections (1-6)',
+    zh: '',
+  },
+  feature: {
+    en: 'Feature section fields',
+    zh: '',
+  },
+  testimonial: {
+    en: 'Testimonial',
+    zh: '',
+  },
+  quote: {
+    en: 'Testimonial quote text',
+    zh: '',
+  },
+  testimonials: {
+    en: 'Testimonial items (exactly 4 required - 1 featured + 3 grid)',
+    zh: '',
+  },
+  authorName: {
+    en: 'Name of the testimonial author',
+    zh: '',
+  },
+  authorRole: {
+    en: 'Role/position of the author',
+    zh: '',
+  },
+  authorImage: {
+    en: 'Author profile image',
+    zh: '',
+  },
+  logos: {
+    en: 'Company logos (1-5)',
+    zh: '',
+  },
+  subheading: {
+    en: 'Subheading text',
+    zh: '',
+  },
+  statsText: {
+    en: 'Stats text shown with icon',
+    zh: '',
+  },
+  contact: {
+    en: 'Contact form fields',
+    zh: '',
+  },
+  list: {
+    en: 'List with icons',
+    zh: '',
+  },
+  submitButton: {
+    en: 'Submit button',
+    zh: '',
+  },
+  fields: {
+    en: 'Fields',
+    zh: '',
+  },
+  supportList: {
+    en: 'Support list',
+    zh: '',
+  },
+  supports: {
+    en: 'Support cards',
+    zh: '',
+  },
+  officeList: {
+    en: 'Office list',
+    zh: '',
+  },
+  offices: {
+    en: 'Office cards',
+    zh: '',
+  },
+  team: {
+    en: 'Team fields',
+    zh: '',
+  },
+  people: {
+    en: 'Members',
+    zh: '',
+  },
+  faq: {
+    en: 'FAQ fields',
+    zh: '',
+  },
+  faqs: {
+    en: 'List FAQ',
+    zh: '',
+  },
+  support: {
+    en: 'Support list',
+    zh: '',
+  },
+  supportLink: {
+    en: 'Support link',
+    zh: '',
+  },
+  header: {
+    en: 'Header fields',
+    zh: '',
+  },
+  menu: {
+    en: 'Header navigation columns',
+    zh: '',
+  },
+  rightSideLinks: {
+    en: 'Right side links',
+    zh: '',
+  },
+  rightLinks: {
+    en: 'Right links',
+    zh: '',
+  },
+  footer: {
+    en: 'Footer fields',
+    zh: '',
+  },
+  copyright: {
+    en: 'Footer copyright',
+    zh: '',
+  },
+  socialLinks: {
+    en: 'Social links',
+    zh: '',
+  },
+  leftLinks: {
+    en: 'Left links',
+    zh: '',
+  },
+  bottomText: {
+    en: 'Bottom text',
+    zh: '',
+  },
+  content: {
+    en: 'Content',
+    zh: '',
+  },
+  filename: {
+    en: 'Filename',
+    zh: '',
+  },
+  mimeType: {
+    en: 'Mime type',
+    zh: '',
+  },
+  filesize: {
+    en: 'Filesize',
+    zh: '',
+  },
+  width: {
+    en: 'Width',
+    zh: '',
+  },
+  height: {
+    en: 'Height',
+    zh: '',
+  },
+} as const

--- a/src/i18n/common-fields.ts
+++ b/src/i18n/common-fields.ts
@@ -1,0 +1,353 @@
+import type { CommonFields } from './types'
+
+// Common fields translation
+export const commonFields: CommonFields = {
+  tenant: {
+    en: 'Tenant',
+    zh: '',
+  },
+  title: {
+    en: 'Title',
+    zh: '标题',
+  },
+  hero: {
+    en: 'Hero',
+    zh: '主图',
+  },
+  meta: {
+    en: 'Meta',
+    zh: '元数据',
+  },
+  image: {
+    en: 'Image',
+    zh: '图片',
+  },
+  description: {
+    en: 'Description',
+    zh: '描述',
+  },
+  publishedAt: {
+    en: 'Published at',
+    zh: '发布时间',
+  },
+  slug: {
+    en: 'Slug',
+    zh: '别名',
+  },
+  slugLock: {
+    en: 'Slug lock',
+    zh: '别名锁定',
+  },
+  _status: {
+    en: '_status',
+    zh: '状态',
+  },
+  subtitle: {
+    en: 'Subtitle text',
+    zh: '副标题',
+  },
+  badge: {
+    en: 'Badge text displayed above title',
+    zh: '徽标',
+  },
+  links: {
+    en: 'Hero buttons',
+    zh: '英雄按钮',
+  },
+  link: {
+    en: 'Hero button',
+    zh: '英雄按钮',
+  },
+  type: {
+    en: 'Type',
+    zh: '类型',
+  },
+  newTab: {
+    en: 'New tab',
+    zh: '新标签页',
+  },
+  reference: {
+    en: 'Reference',
+    zh: '参考',
+  },
+  url: {
+    en: 'Url',
+    zh: 'Url',
+  },
+  label: {
+    en: 'Label',
+    zh: '标签',
+  },
+  prefixIcon: {
+    en: 'Optional: Lucide icon name for prefix (e.g., "ArrowLeft")',
+    zh: '',
+  },
+  suffixIcon: {
+    en: 'Optional: Lucide icon name for suffix (e.g., "ArrowRight")',
+    zh: '',
+  },
+  appearance: {
+    en: 'Choose how the link should be rendered.',
+    zh: '',
+  },
+  rating: {
+    en: 'Rating information',
+    zh: '',
+  },
+  rate: {
+    en: 'Rating value (0-5)',
+    zh: '',
+  },
+  count: {
+    en: 'Number of ratings',
+    zh: '',
+  },
+  avatars: {
+    en: 'User avatars (3-5)',
+    zh: '',
+  },
+  logo: {
+    en: 'Partner logo image',
+    zh: '',
+  },
+  partners: {
+    en: 'Partner logos (1-6)',
+    zh: '',
+  },
+  features: {
+    en: 'Feature list (exactly 4 items)',
+    zh: '',
+  },
+  media: {
+    en: 'Hero media',
+    zh: '',
+  },
+  style: {
+    en: 'Style',
+    zh: '',
+  },
+  blockName: {
+    en: 'Block name',
+    zh: '',
+  },
+  cta: {
+    en: 'CTA section fields',
+    zh: '',
+  },
+  icon: {
+    en: 'Optional: Lucide icon name (e.g., CheckCircle)',
+    zh: '',
+  },
+  lists: {
+    en: 'List with icons',
+    zh: '',
+  },
+  heading: {
+    en: 'The heading text above the title',
+    zh: '',
+  },
+  introContent: {
+    en: 'Intro content',
+    zh: '',
+  },
+  root: {
+    en: 'Root',
+    zh: '',
+  },
+  children: {
+    en: 'Children',
+    zh: '',
+  },
+  version: {
+    en: 'Version',
+    zh: '',
+  },
+  direction: {
+    en: 'Direction',
+    zh: '',
+  },
+  format: {
+    en: 'Format',
+    zh: '',
+  },
+  indent: {
+    en: 'Indent',
+    zh: '',
+  },
+  categories: {
+    en: 'Categories',
+    zh: '',
+  },
+  form: {
+    en: 'Form',
+    zh: '',
+  },
+  gallery: {
+    en: 'Gallery section fields',
+    zh: '',
+  },
+  items: {
+    en: 'Gallery items (1-6)',
+    zh: '',
+  },
+  sections: {
+    en: 'Gallery sections (1-6)',
+    zh: '',
+  },
+  feature: {
+    en: 'Feature section fields',
+    zh: '',
+  },
+  testimonial: {
+    en: 'Testimonial',
+    zh: '',
+  },
+  quote: {
+    en: 'Testimonial quote text',
+    zh: '',
+  },
+  testimonials: {
+    en: 'Testimonial items (exactly 4 required - 1 featured + 3 grid)',
+    zh: '',
+  },
+  authorName: {
+    en: 'Name of the testimonial author',
+    zh: '',
+  },
+  authorRole: {
+    en: 'Role/position of the author',
+    zh: '',
+  },
+  authorImage: {
+    en: 'Author profile image',
+    zh: '',
+  },
+  logos: {
+    en: 'Company logos (1-5)',
+    zh: '',
+  },
+  subheading: {
+    en: 'Subheading text',
+    zh: '',
+  },
+  statsText: {
+    en: 'Stats text shown with icon',
+    zh: '',
+  },
+  contact: {
+    en: 'Contact form fields',
+    zh: '',
+  },
+  list: {
+    en: 'List with icons',
+    zh: '',
+  },
+  submitButton: {
+    en: 'Submit button',
+    zh: '',
+  },
+  fields: {
+    en: 'Fields',
+    zh: '',
+  },
+  supportList: {
+    en: 'Support list',
+    zh: '',
+  },
+  supports: {
+    en: 'Support cards',
+    zh: '',
+  },
+  officeList: {
+    en: 'Office list',
+    zh: '',
+  },
+  offices: {
+    en: 'Office cards',
+    zh: '',
+  },
+  team: {
+    en: 'Team fields',
+    zh: '',
+  },
+  people: {
+    en: 'Members',
+    zh: '',
+  },
+  faq: {
+    en: 'FAQ fields',
+    zh: '',
+  },
+  faqs: {
+    en: 'List FAQ',
+    zh: '',
+  },
+  support: {
+    en: 'Support list',
+    zh: '',
+  },
+  supportLink: {
+    en: 'Support link',
+    zh: '',
+  },
+  header: {
+    en: 'Header fields',
+    zh: '',
+  },
+  menu: {
+    en: 'Header navigation columns',
+    zh: '',
+  },
+  rightSideLinks: {
+    en: 'Right side links',
+    zh: '',
+  },
+  rightLinks: {
+    en: 'Right links',
+    zh: '',
+  },
+  footer: {
+    en: 'Footer fields',
+    zh: '',
+  },
+  copyright: {
+    en: 'Footer copyright',
+    zh: '',
+  },
+  socialLinks: {
+    en: 'Social links',
+    zh: '',
+  },
+  leftLinks: {
+    en: 'Left links',
+    zh: '',
+  },
+  bottomText: {
+    en: 'Bottom text',
+    zh: '',
+  },
+  content: {
+    en: 'Content',
+    zh: '',
+  },
+  filename: {
+    en: 'Filename',
+    zh: '',
+  },
+  mimeType: {
+    en: 'Mime type',
+    zh: '',
+  },
+  filesize: {
+    en: 'Filesize',
+    zh: '',
+  },
+  width: {
+    en: 'Width',
+    zh: '',
+  },
+  height: {
+    en: 'Height',
+    zh: '',
+  },
+} as const

--- a/src/i18n/example-usage.ts
+++ b/src/i18n/example-usage.ts
@@ -1,0 +1,274 @@
+import type { Field, StaticLabel } from 'payload'
+import { createFieldLabel } from '.'
+import type { Translation } from './types'
+
+/**
+ * Convert StaticLabel or string to Translation type
+ */
+function toTranslation(label: StaticLabel | string): Translation {
+  if (typeof label === 'string') {
+    return { en: label, zh: label }
+  }
+  // Handle StaticLabel type
+  return {
+    en: label.en || '',
+    zh: label.zh || '',
+  }
+}
+
+/**
+ * 1. Collection Config
+ */
+export const PostsConfig = {
+  // Collection Label
+  label: createFieldLabel('posts', undefined, 'Posts'),
+
+  // Collection Fields
+  fields: [
+    // Basic Field
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      label: createFieldLabel('title'),
+    },
+
+    // Collection Specific Field
+    {
+      name: 'heroImage',
+      type: 'upload',
+      relationTo: 'media',
+      label: createFieldLabel('heroImage', 'posts', 'Hero Image'),
+    },
+
+    // Field with Default Value
+    {
+      name: 'status',
+      type: 'select',
+      label: createFieldLabel('status', 'posts', 'Status'),
+      defaultValue: 'draft',
+      options: [
+        { label: createFieldLabel('draft', 'posts', 'Draft'), value: 'draft' },
+        { label: createFieldLabel('published', 'posts', 'Published'), value: 'published' },
+      ],
+    },
+  ],
+} satisfies { label: unknown; fields: Partial<Field>[] }
+
+/**
+ * 2. Table Column Config
+ */
+export const tableColumns = [
+  {
+    header: createFieldLabel('title'),
+    accessorKey: 'title',
+  },
+  {
+    header: createFieldLabel('status', 'posts'),
+    accessorKey: 'status',
+  },
+  {
+    header: createFieldLabel('publishedAt', 'posts'),
+    accessorKey: 'publishedAt',
+  },
+]
+
+/**
+ * 3. Validation Messages
+ */
+export const validationMessages = {
+  required: (fieldName: string, collectionName?: string) => {
+    const label = toTranslation(createFieldLabel(fieldName, collectionName))
+    return {
+      en: `${label.en} is required`,
+      zh: `${label.zh}是必填项`,
+    }
+  },
+  invalid: (fieldName: string, collectionName?: string) => {
+    const label = toTranslation(createFieldLabel(fieldName, collectionName))
+    return {
+      en: `${label.en} is invalid`,
+      zh: `${label.zh}格式不正确`,
+    }
+  },
+}
+
+/**
+ * 4. Filter Config
+ */
+export const filterConfig = [
+  {
+    id: 'status',
+    label: createFieldLabel('status', 'posts'),
+    options: [
+      { label: createFieldLabel('draft', 'posts'), value: 'draft' },
+      { label: createFieldLabel('published', 'posts'), value: 'published' },
+    ],
+  },
+  {
+    id: 'category',
+    label: createFieldLabel('category'),
+    options: [
+      { label: createFieldLabel('news', 'categories'), value: 'news' },
+      { label: createFieldLabel('blog', 'categories'), value: 'blog' },
+    ],
+  },
+]
+
+/**
+ * 5. Admin UI Components
+ */
+export const AdminUIConfig = {
+  // Navigation Menu
+  navigation: {
+    posts: {
+      label: createFieldLabel('posts', undefined, 'Posts'),
+      group: createFieldLabel('content', undefined, 'Content'),
+    },
+    media: {
+      label: createFieldLabel('media', undefined, 'Media'),
+      group: createFieldLabel('content', undefined, 'Content'),
+    },
+  },
+
+  // Actions
+  actions: {
+    create: createFieldLabel('create', undefined, 'Create'),
+    edit: createFieldLabel('edit', undefined, 'Edit'),
+    delete: createFieldLabel('delete', undefined, 'Delete'),
+  },
+
+  // Form Validation
+  validation: {
+    messages: {
+      required: (fieldName: string) => validationMessages.required(fieldName),
+      email: () => ({
+        en: 'Please enter a valid email address',
+        zh: '请输入有效的邮箱地址',
+      }),
+    },
+  },
+
+  // Search Placeholder
+  searchPlaceholder: createFieldLabel('searchPlaceholder', undefined, 'Search...'),
+
+  // Bulk Actions
+  bulkActions: {
+    delete: {
+      label: createFieldLabel('bulkDelete', undefined, 'Delete Selected'),
+      confirmMessage: {
+        en: 'Are you sure you want to delete the selected items?',
+        zh: '确定要删除选中的项目吗？',
+      },
+    },
+  },
+}
+
+/**
+ * 6. API Response Messages
+ */
+export const apiMessages = {
+  success: {
+    create: (collectionName: string) => {
+      const label = toTranslation(createFieldLabel(collectionName))
+      return {
+        en: `${label.en} created successfully`,
+        zh: `${label.zh}创建成功`,
+      }
+    },
+    update: (collectionName: string) => {
+      const label = toTranslation(createFieldLabel(collectionName))
+      return {
+        en: `${label.en} updated successfully`,
+        zh: `${label.zh}更新成功`,
+      }
+    },
+    delete: (collectionName: string) => {
+      const label = toTranslation(createFieldLabel(collectionName))
+      return {
+        en: `${label.en} deleted successfully`,
+        zh: `${label.zh}删除成功`,
+      }
+    },
+  },
+  error: {
+    notFound: (collectionName: string) => {
+      const label = toTranslation(createFieldLabel(collectionName))
+      return {
+        en: `${label.en} not found`,
+        zh: `未找到${label.zh}`,
+      }
+    },
+    unauthorized: {
+      en: 'Unauthorized access',
+      zh: '未授权访问',
+    },
+  },
+}
+
+/**
+ * 7. Dynamic Form Fields
+ */
+export const dynamicFormFields = {
+  // Basic Info Form
+  basicInfo: [
+    {
+      name: 'title',
+      label: createFieldLabel('title'),
+      required: true,
+    },
+    {
+      name: 'description',
+      label: createFieldLabel('description'),
+      type: 'textarea',
+    },
+  ],
+
+  // SEO Info Form
+  seoInfo: [
+    {
+      name: 'metaTitle',
+      label: createFieldLabel('metaTitle', undefined, 'Meta Title'),
+      required: true,
+    },
+    {
+      name: 'metaDescription',
+      label: createFieldLabel('metaDescription', undefined, 'Meta Description'),
+      type: 'textarea',
+    },
+  ],
+}
+
+/**
+ * 8. Advanced Usage
+ */
+export const advancedUsage = {
+  // Conditional Rendered Label
+  conditionalLabel: (condition: boolean, fieldName: string) => {
+    const baseLabel = toTranslation(createFieldLabel(fieldName))
+    return condition
+      ? { en: `${baseLabel.en} (Active)`, zh: `${baseLabel.zh} (生效中)` }
+      : baseLabel
+  },
+
+  // Combine Multiple Translations
+  combineTranslations: (parts: Translation[]): Translation => {
+    return {
+      en: parts.map((p) => p.en).join(' '),
+      zh: parts.map((p) => p.zh).join(''),
+    }
+  },
+
+  // Interpolate Translation with Variables
+  interpolateTranslation: (
+    translation: Translation,
+    variables: Record<string, string>,
+  ): Translation => {
+    let { en, zh } = translation
+    Object.entries(variables).forEach(([key, value]) => {
+      en = en.replace(`{${key}}`, value)
+      zh = zh.replace(`{${key}}`, value)
+    })
+    return { en, zh }
+  },
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,81 @@
+import type { StaticLabel } from 'payload'
+import { collections } from './collections'
+import { commonFields } from './common-fields'
+import type { Translation } from './types'
+
+/**
+ * Get translation for a field path
+ * @param fieldPath - Full path to the field (e.g., "hero1.hero.title" or "title")
+ * @param collectionName - Optional collection name if the field is collection-specific
+ * @returns Translation object or undefined if not found
+ */
+export function getFieldTranslation(
+  fieldPath: string,
+  collectionName?: string,
+): Translation | undefined {
+  // Helper to normalize field name
+  function normalizeFieldName(path: string): string {
+    const withoutArray = path.replace(/\[\]/g, '')
+    const parts = withoutArray.split('.')
+    return parts[parts.length - 1] ?? ''
+  }
+
+  // First try to get from common fields
+  const normalizedName = normalizeFieldName(fieldPath)
+  if (normalizedName in commonFields) {
+    return commonFields[normalizedName as keyof typeof commonFields]
+  }
+
+  // If collection is specified, try to get from collection-specific fields
+  if (collectionName && collectionName in collections) {
+    const collection = collections[collectionName as keyof typeof collections]
+    if (fieldPath in collection.fields) {
+      return collection.fields[fieldPath]
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Convert our Translation type to Payload's StaticLabel type
+ */
+function toPayloadLabel(translation: Translation | undefined, defaultLabel: string): StaticLabel {
+  if (!translation) {
+    return defaultLabel
+  }
+  return {
+    en: translation.en || defaultLabel,
+    zh: translation.zh || defaultLabel,
+  }
+}
+
+/**
+ * Create field label with translation
+ * Returns a Payload-compatible label
+ * @param fieldName - The field name to get translation for
+ * @param collectionName - Optional collection name for collection-specific fields
+ * @param defaultLabel - Default label to use if translation is not found
+ * @returns A Payload-compatible label
+ * @example
+ * ```typescript
+ * // Common field
+ * label: createFieldLabel('title')
+ *
+ * // Collection-specific field
+ * label: createFieldLabel('heroImage', 'posts', 'Hero Image')
+ * ```
+ */
+export function createFieldLabel(
+  fieldName: string,
+  collectionName?: string,
+  defaultLabel?: string,
+): StaticLabel {
+  const translation = getFieldTranslation(fieldName, collectionName)
+  return toPayloadLabel(translation, defaultLabel || fieldName)
+}
+
+// Re-export types and translations
+export * from './types'
+export { commonFields } from './common-fields'
+export { collections } from './collections'

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,121 @@
+// Automatically generated types file - do not modify manually
+
+// Basic translation type
+export interface Translation {
+  en: string
+  zh: string
+}
+
+// Common fields translation
+export interface CommonFields {
+  tenant: Translation // Tenant
+  title: Translation // Title
+  hero: Translation // Hero
+  meta: Translation // Meta
+  image: Translation // Maximum upload file size: 12MB. Recommended file size for images is <500KB.
+  description: Translation // Description
+  publishedAt: Translation // Published at
+  slug: Translation // Slug
+  slugLock: Translation // Slug lock
+  _status: Translation // _status
+  subtitle: Translation // Subtitle text
+  badge: Translation // Badge text displayed above title
+  links: Translation // Hero buttons
+  link: Translation // Hero button
+  type: Translation // Type
+  newTab: Translation // New tab
+  reference: Translation // Reference
+  url: Translation // Url
+  label: Translation // Label
+  prefixIcon: Translation // Optional: Lucide icon name for prefix (e.g., "ArrowLeft")
+  suffixIcon: Translation // Optional: Lucide icon name for suffix (e.g., "ArrowRight")
+  appearance: Translation // Choose how the link should be rendered.
+  rating: Translation // Rating information
+  rate: Translation // Rating value (0-5)
+  count: Translation // Number of ratings
+  avatars: Translation // User avatars (3-5)
+  logo: Translation // Partner logo image
+  partners: Translation // Partner logos (1-6)
+  features: Translation // Feature list (exactly 4 items)
+  media: Translation // Hero media
+  style: Translation // Style
+  blockName: Translation // Block name
+  cta: Translation // CTA section fields
+  icon: Translation // Optional: Lucide icon name (e.g., CheckCircle)
+  lists: Translation // List with icons
+  heading: Translation // The heading text above the title
+  introContent: Translation // Intro content
+  root: Translation // Root
+  children: Translation // Children
+  version: Translation // Version
+  direction: Translation // Direction
+  format: Translation // Format
+  indent: Translation // Indent
+  categories: Translation // Categories
+  form: Translation // Form
+  gallery: Translation // Gallery section fields
+  items: Translation // Gallery items (1-6)
+  sections: Translation // Gallery sections (1-6)
+  feature: Translation // Feature section fields
+  testimonial: Translation // Testimonial
+  quote: Translation // Testimonial quote text
+  testimonials: Translation // Testimonial items (exactly 4 required - 1 featured + 3 grid)
+  authorName: Translation // Name of the testimonial author
+  authorRole: Translation // Role/position of the author
+  authorImage: Translation // Author profile image
+  logos: Translation // Company logos (1-5)
+  subheading: Translation // Subheading text
+  statsText: Translation // Stats text shown with icon
+  contact: Translation // Contact form fields
+  list: Translation // List with icons
+  submitButton: Translation // Submit button
+  fields: Translation // Fields
+  supportList: Translation // Support list
+  supports: Translation // Support cards
+  officeList: Translation // Office list
+  offices: Translation // Office cards
+  team: Translation // Team fields
+  people: Translation // Members
+  faq: Translation // FAQ fields
+  faqs: Translation // List FAQ
+  support: Translation // Support list
+  supportLink: Translation // Support link
+  header: Translation // Header fields
+  menu: Translation // Header navigation columns
+  rightSideLinks: Translation // Right side links
+  rightLinks: Translation // Right links
+  footer: Translation // Footer fields
+  copyright: Translation // Footer copyright
+  socialLinks: Translation // Social links
+  leftLinks: Translation // Left links
+  bottomText: Translation // Bottom text
+  content: Translation // Content
+  filename: Translation // Filename
+  mimeType: Translation // Mime type
+  filesize: Translation // Filesize
+  width: Translation // Width
+  height: Translation // Height
+}
+
+// Collection specific field translation type
+export interface CollectionFields {
+  [key: string]: Translation
+}
+
+// Collection labels type
+export interface CollectionLabels {
+  singular: Translation
+  plural: Translation
+  fields: CollectionFields
+}
+
+// All collections type
+export interface Collections {
+  pages: CollectionLabels
+  posts: CollectionLabels
+  media: CollectionLabels
+  categories: CollectionLabels
+  users: CollectionLabels
+  header: CollectionLabels
+  footer: CollectionLabels
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -2,6 +2,8 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { en } from '@payloadcms/translations/languages/en'
+import { zh } from '@payloadcms/translations/languages/zh'
 import { buildConfig, PayloadRequest } from 'payload'
 import sharp from 'sharp' // sharp-import
 import { env } from '@/env'
@@ -22,6 +24,10 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfig({
+  i18n: {
+    fallbackLanguage: 'en',
+    supportedLanguages: { en, zh },
+  },
   admin: {
     components: {
       // The `BeforeLogin` component renders a message that you see while logging into your admin panel.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,8 @@
     "src/types/*.d.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts",
+    "src/i18n/example-usage.ts"
   ]
 }


### PR DESCRIPTION
#47 
- Implemented a comprehensive translation generation script
- Added scripts to automatically generate translation files for collections and common fields
- Integrated internationalization support with Payload CMS
- Created utility functions for field label translations
- Added example usage and documentation for translation workflow
- Updated configuration to support multiple languages (English and Chinese)