### PR TITLE
fix: Failed to Save if All Scripts Removed

### DIFF
--- a/src/collections/CustomCodes/index.ts
+++ b/src/collections/CustomCodes/index.ts
@@ -28,8 +28,8 @@ export const CustomCodes: CollectionConfig = {
     {
       name: 'scripts',
       type: 'array',
-      required: true,
-      minRows: 1,
+      required: false,
+      minRows: 0,
       admin: {
         description: 'Add one or more scripts',
         initCollapsed: true,

--- a/src/components/PayloadRedirects/index.tsx
+++ b/src/components/PayloadRedirects/index.tsx
@@ -16,7 +16,6 @@ export const PayloadRedirects: React.FC<Props> = async ({ disableNotFound, url }
   const redirects = await getRedirects(1, tenant?.id || '')
 
   const redirectItem = redirects?.find((redirect) => redirect.from === url)
-  console.log(url)
 
   if (redirectItem) {
     const isPermanent = redirectItem.type === '301'

--- a/src/globals/CustomCode/Component.tsx
+++ b/src/globals/CustomCode/Component.tsx
@@ -8,7 +8,7 @@ import { SCRIPT_TYPES } from '@/collections/CustomCodes'
 import type { CustomCode as CustomCodeType } from '@/payload-types'
 
 interface ScriptProps {
-  script: CustomCodeType['scripts'][number]
+  script: NonNullable<NonNullable<CustomCodeType['scripts']>[number]>
 }
 
 function ScriptRenderer({ script }: ScriptProps) {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -8336,41 +8336,43 @@ export interface CustomCode {
   /**
    * Add one or more scripts
    */
-  scripts: {
-    /**
-     * A descriptive name for this script
-     */
-    name?: string | null;
-    /**
-     * Select script type for optimized loading
-     */
-    type?: ('google-analytics' | 'google-tag-manager' | 'custom') | null;
-    /**
-     * Enter tracking ID (e.g., G-XXXXXXX for GA4, GTM-XXXXXX for GTM)
-     */
-    trackingId?: string | null;
-    /**
-     * Enter script code
-     */
-    code?: string | null;
-    /**
-     * Enable or disable this script
-     */
-    isEnabled?: boolean | null;
-    /**
-     * Where to place the script in the document
-     */
-    position?: ('head' | 'body-start' | 'body-end') | null;
-    /**
-     * How the script should be loaded
-     */
-    loadingStrategy?: ('sync' | 'async' | 'defer') | null;
-    /**
-     * Optional: URL pattern where this script should load (e.g., "/blog/*" or "/about"). Leave empty for all pages.
-     */
-    urlPattern?: string | null;
-    id?: string | null;
-  }[];
+  scripts?:
+    | {
+        /**
+         * A descriptive name for this script
+         */
+        name?: string | null;
+        /**
+         * Select script type for optimized loading
+         */
+        type?: ('google-analytics' | 'google-tag-manager' | 'custom') | null;
+        /**
+         * Enter tracking ID (e.g., G-XXXXXXX for GA4, GTM-XXXXXX for GTM)
+         */
+        trackingId?: string | null;
+        /**
+         * Enter script code
+         */
+        code?: string | null;
+        /**
+         * Enable or disable this script
+         */
+        isEnabled?: boolean | null;
+        /**
+         * Where to place the script in the document
+         */
+        position?: ('head' | 'body-start' | 'body-end') | null;
+        /**
+         * How the script should be loaded
+         */
+        loadingStrategy?: ('sync' | 'async' | 'defer') | null;
+        /**
+         * Optional: URL pattern where this script should load (e.g., "/blog/*" or "/about"). Leave empty for all pages.
+         */
+        urlPattern?: string | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Overview
This pull request introduces enhancements to the behavior of the Custom Code collection in the admin panel. The changes aim to improve user experience by allowing the collection to be empty without unnecessary alerts or restrictions.

## Current Behavior
### Scene I
- When the Custom Code collection is empty, users visiting the admin panel at `http://localhost:3000/admin/collections/custom-codes` are prompted with an alert if they attempt to navigate away from the page. Users must click "leave anyway" to exit, which can be frustrating.

### Scene II
- After a user creates a script in the Custom Code collection and subsequently deletes it, the collection becomes empty. The system currently prevents users from saving changes when the collection is empty, which can lead to confusion.

## Fixed Enhancement
- Allow the Custom Code collection to be empty without triggering alerts or preventing users from saving changes. This change will enable users to delete scripts they no longer need without facing unnecessary restrictions.

## Benefits
- **Improved User Experience**: Users can manage their scripts more freely, allowing them to delete unnecessary scripts without being hindered by alerts or validation errors.
- **Increased Flexibility**: Users can maintain a clean workspace by removing scripts they no longer require, enhancing overall usability.

## Implementation Approach
- Modify the validation process to allow users to save changes or leave the collection empty without triggering alerts or restrictions.
