### PR TITLE
fix: add hooks when parent get deleted

### DIFF
--- a/src/collections/Pages/hooks/deleteChildPages.ts
+++ b/src/collections/Pages/hooks/deleteChildPages.ts
@@ -1,0 +1,43 @@
+import type { CollectionAfterDeleteHook } from 'payload'
+import type { Page } from '@/payload-types'
+
+export const deleteChildPages: CollectionAfterDeleteHook<Page> = async ({ doc, req, id }) => {
+  try {
+    // Find all pages that have this page as their parent
+    const childPages = await req.payload.find({
+      collection: 'pages',
+      where: {
+        parent: {
+          equals: id,
+        },
+      },
+      depth: 0,
+    })
+
+    // Update each child page to remove parent reference and update path
+    await Promise.all(
+      childPages.docs.map(async (page: Page) => {
+        // Update the child page to remove parent and update fullPath
+        await req.payload.update({
+          collection: 'pages',
+          id: page.id,
+          data: {
+            parent: null, // Remove parent reference
+            fullPath: page.slug, // Reset fullPath to just the slug
+          },
+          context: {
+            disableRevalidate: true, // Prevent revalidation for each child since parent is already deleted
+          },
+        })
+      }),
+    )
+
+    req.payload.logger.info(
+      `Updated ${childPages.docs.length} child pages for deleted parent page ${id}`,
+    )
+  } catch (error) {
+    req.payload.logger.error(`Error updating child pages for deleted parent ${id}:`, error)
+  }
+
+  return doc
+}

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -32,6 +32,7 @@ import { Team } from '../../blocks/Team/config'
 import { TestimonialBlock } from '../../blocks/Testimonial/config'
 import { populatePublishedAt } from '../../hooks/populatePublishedAt'
 import { generatePreviewPath } from '../../utilities/generatePreviewPath'
+import { deleteChildPages } from './hooks/deleteChildPages'
 import { revalidateDelete, revalidatePage } from './hooks/revalidatePage'
 import { updateChildPaths } from './hooks/updateChildPaths'
 
@@ -163,7 +164,7 @@ export const Pages: CollectionConfig<'pages'> = {
   hooks: {
     afterChange: [revalidatePage, updateChildPaths],
     beforeChange: [populatePublishedAt],
-    afterDelete: [revalidateDelete],
+    afterDelete: [deleteChildPages, revalidateDelete],
   },
   versions: {
     drafts: {


### PR DESCRIPTION
## Overview
This pull request introduces hooks that automatically update related child pages when a parent page is deleted. This enhancement ensures data integrity and maintains the hierarchical structure of pages within the application.

## Current Behavior
Currently, when a parent page is deleted, any associated child pages remain unchanged. This can lead to orphaned child pages that still reference the deleted parent, potentially causing confusion and data inconsistency.

## Proposed Enhancement
- Implement hooks that trigger when a parent page is deleted. These hooks will:
  - Automatically update all child pages to remove references to the deleted parent.
  - Optionally reset any relevant fields in the child pages, such as the `fullPath` or `parent` reference, to maintain a clean state.

## Benefits
- **Data Integrity**: Ensures that child pages do not reference deleted parent pages, maintaining a consistent and accurate data structure.
- **Improved User Experience**: Reduces the likelihood of orphaned child pages, making it easier for users to manage their content without encountering broken links or references.
- **Automated Cleanup**: Automates the process of updating child pages, saving users from having to manually adjust related content after a parent page deletion.

## Implementation Approach
- Add a hook to the deletion process of parent pages that retrieves all related child pages.
- Update the child pages to remove the parent reference and reset any necessary fields.
-