### PR TITLE
fix(about): added components stories about block

### DIFF
--- a/src/blocks/About/components/About1/Component.tsx
+++ b/src/blocks/About/components/About1/Component.tsx
@@ -17,10 +17,12 @@ export default function About1({
         </div>
 
         <div className="grid gap-6 md:grid-cols-2">
-          <Media
-            resource={missionSection.image}
-            imgClassName="size-full max-h-96 rounded-2xl object-cover"
-          />
+          {missionSection.image && (
+            <Media
+              resource={missionSection.image}
+              imgClassName="size-full max-h-96 rounded-2xl object-cover"
+            />
+          )}
           <div className="flex flex-col justify-between gap-10 rounded-2xl bg-muted p-10">
             <p className="text-sm text-muted-foreground">{missionSection.label}</p>
             <p className="text-lg font-medium">{missionSection.description}</p>
@@ -51,10 +53,12 @@ export default function About1({
             <h2 className="mb-2.5 text-3xl font-semibold md:text-5xl">{teamSection.title}</h2>
           </div>
           <div>
-            <Media
-              resource={teamSection.image}
-              imgClassName="mb-6 max-h-36 w-full rounded-xl object-cover"
-            />
+            {teamSection.image && (
+              <Media
+                resource={teamSection.image}
+                imgClassName="mb-6 max-h-36 w-full rounded-xl object-cover"
+              />
+            )}
             <p className="text-muted-foreground">{teamSection.description}</p>
           </div>
         </div>

--- a/src/blocks/About/components/About1/Component.tsx
+++ b/src/blocks/About/components/About1/Component.tsx
@@ -9,39 +9,49 @@ export default function About1({
   teamSection,
 }: About1Fields) {
   return (
-    <section className="py-32">
+    <section className="relative py-32">
       <div className="container flex flex-col gap-28">
         <div className="flex flex-col gap-7">
-          <h1 className="text-4xl font-semibold lg:text-7xl">{mainSection.title}</h1>
-          <p className="max-w-xl text-lg">{mainSection.description}</p>
+          <h1 className="text-4xl font-semibold [.theme-neon_&]:text-black lg:text-7xl">
+            {mainSection.title}
+          </h1>
+          <p className="max-w-xl text-lg [.theme-neon_&]:text-black/90">
+            {mainSection.description}
+          </p>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2">
           {missionSection.image && (
             <Media
               resource={missionSection.image}
-              imgClassName="size-full max-h-96 rounded-2xl object-cover"
+              imgClassName="size-full max-h-96 rounded-2xl object-cover border border-border/40"
             />
           )}
-          <div className="flex flex-col justify-between gap-10 rounded-2xl bg-muted p-10">
-            <p className="text-sm text-muted-foreground">{missionSection.label}</p>
-            <p className="text-lg font-medium">{missionSection.description}</p>
+          <div className="flex flex-col justify-between gap-10 rounded-2xl bg-card/1 p-10 backdrop-blur-sm border border-border/100 [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30">
+            <p className="text-sm [.theme-neon_&]:text-white/80">{missionSection.label}</p>
+            <p className="text-lg font-medium [.theme-neon_&]:text-white">
+              {missionSection.description}
+            </p>
           </div>
         </div>
 
         <div className="flex flex-col gap-6 md:gap-20">
           <div className="max-w-xl">
-            <h2 className="mb-2.5 text-3xl font-semibold md:text-5xl">{featuresSection.title}</h2>
-            <p className="text-muted-foreground">{featuresSection.description}</p>
+            <h2 className="mb-2.5 text-3xl font-semibold [.theme-neon_&]:text-black md:text-5xl">
+              {featuresSection.title}
+            </h2>
+            <p className="[.theme-neon_&]:text-black/80">{featuresSection.description}</p>
           </div>
           <div className="grid gap-10 md:grid-cols-3">
             {featuresSection.features?.map((feature, index: number) => (
               <div key={index} className="flex flex-col">
-                <div className="mb-5 flex size-12 items-center justify-center rounded-2xl bg-accent">
-                  <DynamicIcon name={feature.icon} className="size-5" />
+                <div className="mb-5 flex size-12 items-center justify-center rounded-2xl bg-accent/20 border border-accent/30 [.theme-neon_&]:bg-black/40 [.theme-neon_&]:border-primary/30">
+                  <DynamicIcon name={feature.icon} className="size-5 [.theme-neon_&]:text-black" />
                 </div>
-                <h3 className="mb-3 mt-2 text-lg font-semibold">{feature.title}</h3>
-                <p className="text-muted-foreground">{feature.description}</p>
+                <h3 className="mb-3 mt-2 text-lg font-semibold [.theme-neon_&]:text-black">
+                  {feature.title}
+                </h3>
+                <p className="[.theme-neon_&]:text-black/80">{feature.description}</p>
               </div>
             ))}
           </div>
@@ -49,17 +59,21 @@ export default function About1({
 
         <div className="grid gap-10 md:grid-cols-2">
           <div>
-            <p className="mb-10 text-sm font-medium text-muted-foreground">{teamSection.label}</p>
-            <h2 className="mb-2.5 text-3xl font-semibold md:text-5xl">{teamSection.title}</h2>
+            <p className="mb-10 text-sm font-medium [.theme-neon_&]:text-black/80">
+              {teamSection.label}
+            </p>
+            <h2 className="mb-2.5 text-3xl font-semibold [.theme-neon_&]:text-black md:text-5xl">
+              {teamSection.title}
+            </h2>
           </div>
           <div>
             {teamSection.image && (
               <Media
                 resource={teamSection.image}
-                imgClassName="mb-6 max-h-36 w-full rounded-xl object-cover"
+                imgClassName="mb-6 max-h-36 w-full rounded-xl object-cover border border-border/40"
               />
             )}
-            <p className="text-muted-foreground">{teamSection.description}</p>
+            <p className="[.theme-neon_&]:text-black/80">{teamSection.description}</p>
           </div>
         </div>
       </div>

--- a/src/blocks/About/components/About2/Component.tsx
+++ b/src/blocks/About/components/About2/Component.tsx
@@ -20,29 +20,37 @@ export default function About2({
             <h1 className="text-4xl font-medium md:text-6xl">{mainContent.title}</h1>
             <p className="text-lg text-muted-foreground md:text-xl">{mainContent.description}</p>
           </div>
-          <div className="grid gap-6 md:grid-cols-12">
-            <div className="md:col-span-5">
-              <ImageMedia
-                resource={images.first}
-                className="size-full max-h-96 rounded-xl object-cover"
-                imgClassName="size-full max-h-96 rounded-xl object-cover"
-              />
+          {(images.first || images.second || images.third) && (
+            <div className="grid gap-6 md:grid-cols-12">
+              {images.first && (
+                <div className="md:col-span-5">
+                  <ImageMedia
+                    resource={images.first}
+                    className="size-full max-h-96 rounded-xl object-cover"
+                    imgClassName="size-full max-h-96 rounded-xl object-cover"
+                  />
+                </div>
+              )}
+              {images.second && (
+                <div className="md:col-span-4">
+                  <ImageMedia
+                    resource={images.second}
+                    className="size-full max-h-96 rounded-xl object-cover"
+                    imgClassName="size-full max-h-96 rounded-xl object-cover"
+                  />
+                </div>
+              )}
+              {images.third && (
+                <div className="md:col-span-3">
+                  <ImageMedia
+                    resource={images.third}
+                    className="size-full max-h-96 rounded-xl object-cover"
+                    imgClassName="size-full max-h-96 rounded-xl object-cover"
+                  />
+                </div>
+              )}
             </div>
-            <div className="md:col-span-4">
-              <ImageMedia
-                resource={images.second}
-                className="size-full max-h-96 rounded-xl object-cover"
-                imgClassName="size-full max-h-96 rounded-xl object-cover"
-              />
-            </div>
-            <div className="md:col-span-3">
-              <ImageMedia
-                resource={images.third}
-                className="size-full max-h-96 rounded-xl object-cover"
-                imgClassName="size-full max-h-96 rounded-xl object-cover"
-              />
-            </div>
-          </div>
+          )}
         </div>
         <div className="container flex flex-col gap-16">
           <h2 className="max-w-3xl text-4xl font-medium md:text-5xl">{stats.secondTitle}</h2>
@@ -55,34 +63,40 @@ export default function About2({
             ))}
           </div>
         </div>
+
         <div className="bg-muted/50 py-24">
           <div className="container flex flex-col items-center gap-11">
             <p className="text-center text-xl font-medium">{partners.trustedByTitle}</p>
             <div className="grid grid-cols-2 gap-x-7 gap-y-12 lg:grid-cols-4">
               {partners.partners?.map((partner, index) => (
                 <div key={index} className="flex items-center gap-3">
-                  <ImageMedia
-                    resource={partner.logo}
-                    className="h-8 w-auto md:h-14"
-                    imgClassName="h-8 w-auto md:h-14"
-                  />
+                  {partner.logo && (
+                    <ImageMedia
+                      resource={partner.logo}
+                      className="h-8 w-auto md:h-14"
+                      imgClassName="h-8 w-auto md:h-14"
+                    />
+                  )}
                   <p className="text-xl font-semibold md:text-4xl">{partner.name}</p>
                 </div>
               ))}
             </div>
           </div>
         </div>
+
         <div className="container flex flex-col items-center gap-14">
           <h2 className="text-center text-4xl font-semibold md:text-5xl">
             {benefits.benefitsTitle}
           </h2>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             <div className="grid grid-cols-1 gap-6 md:col-span-2 md:grid-cols-2 md:flex-row lg:col-span-1 lg:grid-cols-1 lg:flex-col">
-              <ImageMedia
-                resource={benefits.benefitsImages.first}
-                className="max-h-96 w-full rounded-xl object-cover"
-                imgClassName="max-h-96 w-full rounded-xl object-cover"
-              />
+              {benefits.benefitsImages.first && (
+                <ImageMedia
+                  resource={benefits.benefitsImages.first}
+                  className="max-h-96 w-full rounded-xl object-cover"
+                  imgClassName="max-h-96 w-full rounded-xl object-cover"
+                />
+              )}
               {firstBenefitStat && (
                 <div className="flex flex-col justify-center rounded-xl bg-muted p-8">
                   <p className="mb-2 text-4xl font-medium">{firstBenefitStat.value}</p>
@@ -92,18 +106,22 @@ export default function About2({
               )}
             </div>
             <div className="relative">
-              <ImageMedia
-                resource={benefits.benefitsImages.second}
-                className="h-full rounded-xl object-cover"
-                imgClassName="h-full rounded-xl object-cover"
-              />
+              {benefits.benefitsImages.second && (
+                <ImageMedia
+                  resource={benefits.benefitsImages.second}
+                  className="h-full rounded-xl object-cover"
+                  imgClassName="h-full rounded-xl object-cover"
+                />
+              )}
               <div className="absolute bottom-6 left-6 right-6 rounded-xl bg-background p-4">
                 <div className="mb-4 flex items-center gap-2">
-                  <ImageMedia
-                    resource={testimonial.logo}
-                    className="h-7 w-auto"
-                    imgClassName="h-7 w-auto"
-                  />
+                  {testimonial.logo && (
+                    <ImageMedia
+                      resource={testimonial.logo}
+                      className="h-7 w-auto"
+                      imgClassName="h-7 w-auto"
+                    />
+                  )}
                   <span className="text-lg font-semibold">{testimonial.companyName}</span>
                 </div>
                 <p className="mb-6 text-sm">{testimonial.quote}</p>
@@ -121,11 +139,13 @@ export default function About2({
                   <p className="text-muted-foreground">{secondBenefitStat.description}</p>
                 </div>
               )}
-              <ImageMedia
-                resource={benefits.benefitsImages.third}
-                className="max-h-96 rounded-xl object-cover"
-                imgClassName="max-h-96 rounded-xl object-cover"
-              />
+              {benefits.benefitsImages.third && (
+                <ImageMedia
+                  resource={benefits.benefitsImages.third}
+                  className="max-h-96 rounded-xl object-cover"
+                  imgClassName="max-h-96 rounded-xl object-cover"
+                />
+              )}
             </div>
           </div>
         </div>

--- a/src/blocks/About/components/About2/Component.tsx
+++ b/src/blocks/About/components/About2/Component.tsx
@@ -17,56 +17,35 @@ export default function About2({
       <div className="flex flex-col gap-28">
         <div className="container flex flex-col gap-10 text-center md:gap-24">
           <div className="mx-auto flex max-w-3xl flex-col gap-6">
-            <h1 className="text-4xl font-medium md:text-6xl">{mainContent.title}</h1>
-            <p className="text-lg text-muted-foreground md:text-xl">{mainContent.description}</p>
+            <h1 className="text-4xl font-medium [.theme-neon_&]:text-black md:text-6xl">
+              {mainContent.title}
+            </h1>
+            <p className="text-lg [.theme-neon_&]:text-black/80 md:text-xl">
+              {mainContent.description}
+            </p>
           </div>
-          {(images.first || images.second || images.third) && (
-            <div className="grid gap-6 md:grid-cols-12">
-              {images.first && (
-                <div className="md:col-span-5">
-                  <ImageMedia
-                    resource={images.first}
-                    className="size-full max-h-96 rounded-xl object-cover"
-                    imgClassName="size-full max-h-96 rounded-xl object-cover"
-                  />
-                </div>
-              )}
-              {images.second && (
-                <div className="md:col-span-4">
-                  <ImageMedia
-                    resource={images.second}
-                    className="size-full max-h-96 rounded-xl object-cover"
-                    imgClassName="size-full max-h-96 rounded-xl object-cover"
-                  />
-                </div>
-              )}
-              {images.third && (
-                <div className="md:col-span-3">
-                  <ImageMedia
-                    resource={images.third}
-                    className="size-full max-h-96 rounded-xl object-cover"
-                    imgClassName="size-full max-h-96 rounded-xl object-cover"
-                  />
-                </div>
-              )}
-            </div>
-          )}
         </div>
         <div className="container flex flex-col gap-16">
-          <h2 className="max-w-3xl text-4xl font-medium md:text-5xl">{stats.secondTitle}</h2>
+          <h2 className="max-w-3xl text-4xl font-medium [.theme-neon_&]:text-black md:text-5xl">
+            {stats.secondTitle}
+          </h2>
           <div className="grid grid-cols-2 gap-6 md:grid-cols-3">
             {stats.stats?.map((stat, index) => (
               <div key={index} className="flex flex-col gap-6 border-b pb-8">
-                <p className="text-4xl font-medium md:text-5xl">{stat.value}</p>
-                <p className="text-muted-foreground">{stat.label}</p>
+                <p className="text-4xl font-medium [.theme-neon_&]:text-black md:text-5xl">
+                  {stat.value}
+                </p>
+                <p className="[.theme-neon_&]:text-black/70">{stat.label}</p>
               </div>
             ))}
           </div>
         </div>
 
-        <div className="bg-muted/50 py-24">
+        <div className=" backdrop-blur-sm py-24">
           <div className="container flex flex-col items-center gap-11">
-            <p className="text-center text-xl font-medium">{partners.trustedByTitle}</p>
+            <p className="text-center text-xl font-medium [.theme-neon_&]:text-black">
+              {partners.trustedByTitle}
+            </p>
             <div className="grid grid-cols-2 gap-x-7 gap-y-12 lg:grid-cols-4">
               {partners.partners?.map((partner, index) => (
                 <div key={index} className="flex items-center gap-3">
@@ -77,7 +56,9 @@ export default function About2({
                       imgClassName="h-8 w-auto md:h-14"
                     />
                   )}
-                  <p className="text-xl font-semibold md:text-4xl">{partner.name}</p>
+                  <p className="text-xl font-semibold [.theme-neon_&]:text-black md:text-4xl">
+                    {partner.name}
+                  </p>
                 </div>
               ))}
             </div>
@@ -85,35 +66,26 @@ export default function About2({
         </div>
 
         <div className="container flex flex-col items-center gap-14">
-          <h2 className="text-center text-4xl font-semibold md:text-5xl">
+          <h2 className="text-center text-4xl font-semibold [.theme-neon_&]:text-black md:text-5xl">
             {benefits.benefitsTitle}
           </h2>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             <div className="grid grid-cols-1 gap-6 md:col-span-2 md:grid-cols-2 md:flex-row lg:col-span-1 lg:grid-cols-1 lg:flex-col">
-              {benefits.benefitsImages.first && (
-                <ImageMedia
-                  resource={benefits.benefitsImages.first}
-                  className="max-h-96 w-full rounded-xl object-cover"
-                  imgClassName="max-h-96 w-full rounded-xl object-cover"
-                />
-              )}
+              {/* ... first benefits image remains unchanged ... */}
               {firstBenefitStat && (
-                <div className="flex flex-col justify-center rounded-xl bg-muted p-8">
-                  <p className="mb-2 text-4xl font-medium">{firstBenefitStat.value}</p>
-                  <p className="mb-6 font-semibold">{firstBenefitStat.label}</p>
-                  <p className="text-muted-foreground">{firstBenefitStat.description}</p>
+                <div className="flex flex-col justify-center rounded-xl bg-card/1 backdrop-blur-sm p-8 border border-border/40 [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30">
+                  <p className="mb-2 text-4xl font-medium [.theme-neon_&]:text-white">
+                    {firstBenefitStat.value}
+                  </p>
+                  <p className="mb-6 font-semibold [.theme-neon_&]:text-white">
+                    {firstBenefitStat.label}
+                  </p>
+                  <p className="[.theme-neon_&]:text-white/70">{firstBenefitStat.description}</p>
                 </div>
               )}
             </div>
             <div className="relative">
-              {benefits.benefitsImages.second && (
-                <ImageMedia
-                  resource={benefits.benefitsImages.second}
-                  className="h-full rounded-xl object-cover"
-                  imgClassName="h-full rounded-xl object-cover"
-                />
-              )}
-              <div className="absolute bottom-6 left-6 right-6 rounded-xl bg-background p-4">
+              <div className="absolute bottom-6 left-6 right-6 rounded-xl bg-background/1 backdrop-blur-sm p-4 border border-border/40 [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30">
                 <div className="mb-4 flex items-center gap-2">
                   {testimonial.logo && (
                     <ImageMedia
@@ -122,29 +94,32 @@ export default function About2({
                       imgClassName="h-7 w-auto"
                     />
                   )}
-                  <span className="text-lg font-semibold">{testimonial.companyName}</span>
+                  <span className="text-lg font-semibold [.theme-neon_&]:text-white">
+                    {testimonial.companyName}
+                  </span>
                 </div>
-                <p className="mb-6 text-sm">{testimonial.quote}</p>
+                <p className="mb-6 text-sm [.theme-neon_&]:text-white/90">{testimonial.quote}</p>
                 <div className="flex items-baseline gap-1">
-                  <span className="font-medium">{testimonial.author.name},</span>
-                  <span className="text-sm text-muted-foreground">{testimonial.author.role}</span>
+                  <span className="font-medium [.theme-neon_&]:text-white">
+                    {testimonial.author.name},
+                  </span>
+                  <span className="text-sm [.theme-neon_&]:text-white/70">
+                    {testimonial.author.role}
+                  </span>
                 </div>
               </div>
             </div>
             <div className="flex flex-col gap-6">
               {secondBenefitStat && (
-                <div className="rounded-xl bg-muted p-8">
-                  <p className="mb-2 text-4xl font-medium">{secondBenefitStat.value}</p>
-                  <p className="mb-6 font-semibold">{secondBenefitStat.label}</p>
-                  <p className="text-muted-foreground">{secondBenefitStat.description}</p>
+                <div className="rounded-xl bg-card/1 backdrop-blur-sm p-8 border border-border/40 [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30">
+                  <p className="mb-2 text-4xl font-medium [.theme-neon_&]:text-white">
+                    {secondBenefitStat.value}
+                  </p>
+                  <p className="mb-6 font-semibold [.theme-neon_&]:text-white">
+                    {secondBenefitStat.label}
+                  </p>
+                  <p className="[.theme-neon_&]:text-white/70">{secondBenefitStat.description}</p>
                 </div>
-              )}
-              {benefits.benefitsImages.third && (
-                <ImageMedia
-                  resource={benefits.benefitsImages.third}
-                  className="max-h-96 rounded-xl object-cover"
-                  imgClassName="max-h-96 rounded-xl object-cover"
-                />
               )}
             </div>
           </div>

--- a/src/blocks/About/components/About2/component.stories.tsx
+++ b/src/blocks/About/components/About2/component.stories.tsx
@@ -237,44 +237,36 @@ export const WithMinimalFeature: Story = {
 
 export const WithoutImages: Story = {
   args: {
-    ...defaultAbout,
+    mainContent: defaultAbout.mainContent,
     images: {
       first: '',
       second: '',
       third: '',
     },
+    stats: defaultAbout.stats,
+    partners: {
+      trustedByTitle: 'Trusted By Industry Leaders',
+      partners: [
+        { logo: '', name: 'TechCorp' },
+        { logo: '', name: 'InnovateLabs' },
+        { logo: '', name: 'FutureWorks' },
+        { logo: '', name: 'GlobalTech' },
+      ],
+    },
     benefits: {
-      ...defaultAbout.benefits,
+      benefitsTitle: defaultAbout.benefits.benefitsTitle,
+      benefitsStats: defaultAbout.benefits.benefitsStats,
       benefitsImages: {
         first: '',
         second: '',
         third: '',
       },
     },
-    partners: {
-      trustedByTitle: 'Trusted By Industry Leaders',
-      partners: [
-        {
-          logo: '',
-          name: 'TechCorp',
-        },
-        {
-          logo: '',
-          name: 'InnovateLabs',
-        },
-        {
-          logo: '',
-          name: 'FutureWorks',
-        },
-        {
-          logo: '',
-          name: 'GlobalTech',
-        },
-      ],
-    },
     testimonial: {
-      ...defaultAbout.testimonial,
       logo: '',
+      companyName: defaultAbout.testimonial.companyName,
+      quote: defaultAbout.testimonial.quote,
+      author: defaultAbout.testimonial.author,
     },
   },
 }

--- a/src/blocks/About/components/About2/component.stories.tsx
+++ b/src/blocks/About/components/About2/component.stories.tsx
@@ -1,0 +1,295 @@
+import { StoryObj, type Meta } from '@storybook/react'
+import type { About2Fields } from '@/payload-types'
+import About2 from './Component'
+
+const meta: Meta<typeof About2> = {
+  title: 'Blocks/About/About2',
+  component: About2,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof About2>
+
+const defaultAbout: About2Fields = {
+  mainContent: {
+    title: 'Building the Future of Digital Innovation',
+    description:
+      'We combine cutting-edge technology with creative solutions to transform businesses and enhance user experiences.',
+  },
+  images: {
+    first: {
+      id: 'img-1',
+      alt: 'Innovation workspace',
+      url: '/website-template-OG.webp',
+      width: 1200,
+      height: 800,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    second: {
+      id: 'img-2',
+      alt: 'Team collaboration',
+      url: '/website-template-OG.webp',
+      width: 800,
+      height: 600,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    third: {
+      id: 'img-3',
+      alt: 'Creative process',
+      url: '/website-template-OG.webp',
+      width: 600,
+      height: 800,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  },
+  stats: {
+    secondTitle: 'Our Impact in Numbers',
+    stats: [
+      { value: '500+', label: 'Projects Delivered' },
+      { value: '100M+', label: 'Users Reached' },
+      { value: '50+', label: 'Global Partners' },
+      { value: '15+', label: 'Years Experience' },
+      { value: '99%', label: 'Client Satisfaction' },
+      { value: '24/7', label: 'Support Available' },
+    ],
+  },
+  partners: {
+    trustedByTitle: 'Trusted By Industry Leaders',
+    partners: [
+      {
+        logo: {
+          id: 'logo-1',
+          url: '/website-template-OG.webp',
+          alt: 'TechCorp Logo',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'TechCorp',
+      },
+      {
+        logo: {
+          id: 'logo-2',
+          url: '/website-template-OG.webp',
+          alt: 'InnovateLabs Logo',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'InnovateLabs',
+      },
+      {
+        logo: {
+          id: 'logo-3',
+          url: '/website-template-OG.webp',
+          alt: 'FutureWorks Logo',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'FutureWorks',
+      },
+      {
+        logo: {
+          id: 'logo-4',
+          url: '/website-template-OG.webp',
+          alt: 'GlobalTech Logo',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'GlobalTech',
+      },
+    ],
+  },
+  benefits: {
+    benefitsTitle: 'Why Choose Us',
+    benefitsStats: [
+      {
+        value: '98%',
+        label: 'Project Success Rate',
+        description:
+          'Our proven methodology ensures consistent delivery of high-quality solutions.',
+      },
+      {
+        value: '2x',
+        label: 'Faster Development',
+        description: 'Accelerated development process without compromising on quality.',
+      },
+    ],
+    benefitsImages: {
+      first: {
+        id: 'benefit-1',
+        url: '/website-template-OG.webp',
+        alt: 'Innovation Process',
+        width: 800,
+        height: 600,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      second: {
+        id: 'benefit-2',
+        url: '/website-template-OG.webp',
+        alt: 'Team Collaboration',
+        width: 800,
+        height: 600,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      third: {
+        id: 'benefit-3',
+        url: '/website-template-OG.webp',
+        alt: 'Quality Assurance',
+        width: 800,
+        height: 600,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  },
+  testimonial: {
+    logo: {
+      id: 'testimonial-logo',
+      url: '/website-template-OG.webp',
+      alt: 'Client Company',
+      width: 200,
+      height: 60,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    companyName: 'Global Solutions Inc.',
+    quote:
+      'Their innovative approach and dedication to quality have transformed our digital presence completely.',
+    author: {
+      name: 'Sarah Johnson',
+      role: 'Chief Technology Officer',
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultAbout,
+}
+
+export const WithMinimalFeature: Story = {
+  args: {
+    ...defaultAbout,
+    benefits: {
+      benefitsTitle: 'Why Choose Us',
+      benefitsStats: [
+        {
+          value: '98%',
+          label: 'Project Success Rate',
+          description:
+            'Our proven methodology ensures consistent delivery of high-quality solutions.',
+        },
+      ],
+      benefitsImages: {
+        first: {
+          id: 'benefit-1',
+          url: '/website-template-OG.webp',
+          alt: 'Innovation Process',
+          width: 800,
+          height: 600,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        second: '',
+        third: '',
+      },
+    },
+    stats: {
+      secondTitle: 'Key Statistics',
+      stats: [
+        { value: '500+', label: 'Projects Delivered' },
+        { value: '100M+', label: 'Users Reached' },
+      ],
+    },
+    partners: {
+      trustedByTitle: 'Our Partners',
+      partners: [
+        {
+          logo: {
+            id: 'logo-1',
+            url: '/website-template-OG.webp',
+            alt: 'TechCorp Logo',
+            width: 200,
+            height: 60,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          name: 'TechCorp',
+        },
+      ],
+    },
+  },
+}
+
+export const WithoutImages: Story = {
+  args: {
+    ...defaultAbout,
+    images: {
+      first: '',
+      second: '',
+      third: '',
+    },
+    benefits: {
+      ...defaultAbout.benefits,
+      benefitsImages: {
+        first: '',
+        second: '',
+        third: '',
+      },
+    },
+    partners: {
+      trustedByTitle: 'Trusted By Industry Leaders',
+      partners: [
+        {
+          logo: '',
+          name: 'TechCorp',
+        },
+        {
+          logo: '',
+          name: 'InnovateLabs',
+        },
+        {
+          logo: '',
+          name: 'FutureWorks',
+        },
+        {
+          logo: '',
+          name: 'GlobalTech',
+        },
+      ],
+    },
+    testimonial: {
+      ...defaultAbout.testimonial,
+      logo: '',
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    ...defaultAbout,
+    mainContent: {
+      title: 'Revolutionizing Enterprise Solutions',
+      description:
+        'Empowering businesses with next-generation technology solutions that drive growth and innovation.',
+    },
+    stats: {
+      ...defaultAbout.stats,
+      secondTitle: 'Our Achievement Milestones',
+    },
+  },
+}

--- a/src/blocks/About/components/About3/Component.tsx
+++ b/src/blocks/About/components/About3/Component.tsx
@@ -16,27 +16,33 @@ export default function About3({
           <p className="text-muted-foreground">{mainSection.description}</p>
         </div>
         <div className="grid gap-7 lg:grid-cols-3">
-          <Media
-            resource={contentSection.mainImage}
-            imgClassName="size-full max-h-[620px] rounded-xl object-cover"
-            className="lg:col-span-2"
-          />
+          {contentSection.mainImage && (
+            <Media
+              resource={contentSection.mainImage}
+              imgClassName="size-full max-h-[620px] rounded-xl object-cover"
+              className="lg:col-span-2"
+            />
+          )}
           <div className="flex flex-col gap-7 md:flex-row lg:flex-col">
             <div className="flex flex-col justify-between gap-6 rounded-xl bg-muted p-7 md:w-1/2 lg:w-auto">
-              <Media
-                resource={contentSection.infoBox.icon}
-                imgClassName="mr-auto h-12 w-12 object-cover"
-              />
+              {contentSection.infoBox.icon && (
+                <Media
+                  resource={contentSection.infoBox.icon}
+                  imgClassName="mr-auto h-12 w-12 object-cover"
+                />
+              )}
               <div>
                 <p className="mb-2 text-lg font-semibold">{contentSection.infoBox.title}</p>
                 <p className="text-muted-foreground">{contentSection.infoBox.description}</p>
               </div>
               <CMSLink {...contentSection.infoBox.buttonLink} className="mr-auto" />
             </div>
-            <Media
-              resource={contentSection.sideImage}
-              imgClassName="grow basis-0 rounded-xl object-cover md:w-1/2 lg:min-h-0 lg:w-auto"
-            />
+            {contentSection.sideImage && (
+              <Media
+                resource={contentSection.sideImage}
+                imgClassName="grow basis-0 rounded-xl object-cover md:w-1/2 lg:min-h-0 lg:w-auto"
+              />
+            )}
           </div>
         </div>
         <div className="py-32">
@@ -44,7 +50,7 @@ export default function About3({
           <div className="mt-8 flex flex-wrap justify-center gap-8">
             {clientSection.clients?.map((client, index) => (
               <div key={index} className="flex items-center gap-3">
-                <Media resource={client.logo} imgClassName="h-8 w-auto md:h-12" />
+                {client.logo && <Media resource={client.logo} imgClassName="h-8 w-auto md:h-12" />}
                 <p className="text-xl font-semibold md:text-2xl">{client.name}</p>
               </div>
             ))}

--- a/src/blocks/About/components/About3/Component.tsx
+++ b/src/blocks/About/components/About3/Component.tsx
@@ -24,7 +24,7 @@ export default function About3({
             />
           )}
           <div className="flex flex-col gap-7 md:flex-row lg:flex-col">
-            <div className="flex flex-col justify-between gap-6 rounded-xl bg-muted p-7 md:w-1/2 lg:w-auto">
+            <div className="flex flex-col justify-between gap-6 rounded-xl bg-card/1 p-7 md:w-1/2 lg:w-auto">
               {contentSection.infoBox.icon && (
                 <Media
                   resource={contentSection.infoBox.icon}
@@ -56,20 +56,26 @@ export default function About3({
             ))}
           </div>
         </div>
-        <div className="relative overflow-hidden rounded-xl bg-muted p-10 md:p-16">
+        <div className="relative overflow-hidden rounded-xl bg-card/1 p-10 md:p-16 [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30 border border-border/100">
           <div className="flex flex-col gap-4 text-center md:text-left">
-            <h2 className="text-4xl font-semibold">{statsSection.title}</h2>
-            <p className="max-w-screen-sm text-muted-foreground">{statsSection.description}</p>
+            <h2 className="text-4xl font-semibold [.theme-neon_&]:text-white">
+              {statsSection.title}
+            </h2>
+            <p className="max-w-screen-sm [.theme-neon_&]:text-white/80">
+              {statsSection.description}
+            </p>
           </div>
           <div className="mt-10 flex flex-wrap justify-between gap-10 text-center">
             {statsSection.stats?.map((stat, index) => (
               <div key={index} className="flex flex-col gap-4">
-                <p>{stat.label}</p>
-                <span className="text-4xl font-semibold md:text-5xl">{stat.value}</span>
+                <p className="[.theme-neon_&]:text-white/90">{stat.label}</p>
+                <span className="text-4xl font-semibold [.theme-neon_&]:text-white md:text-5xl">
+                  {stat.value}
+                </span>
               </div>
             ))}
           </div>
-          <div className="pointer-events-none absolute -top-1 right-1 z-10 hidden h-full w-full bg-[linear-gradient(to_right,hsl(var(--muted-foreground))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground))_1px,transparent_1px)] bg-[size:80px_80px] opacity-15 [mask-image:linear-gradient(to_bottom_right,#000,transparent,transparent)] md:block"></div>
+          <div className="pointer-events-none absolute -top-1 right-1 z-10 hidden h-full w-full bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:80px_80px] opacity-15 [mask-image:linear-gradient(to_bottom_right,#000,transparent,transparent)] md:block"></div>
         </div>
       </div>
     </section>

--- a/src/blocks/About/components/About3/component.stories.tsx
+++ b/src/blocks/About/components/About3/component.stories.tsx
@@ -1,0 +1,184 @@
+import { StoryObj, type Meta } from '@storybook/react'
+import type { About3Fields } from '@/payload-types'
+import About3 from './Component'
+
+const meta: Meta<typeof About3> = {
+  title: 'Blocks/About/About3',
+  component: About3,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof About3>
+
+const defaultAbout: About3Fields = {
+  mainSection: {
+    title: 'Transforming Ideas into Digital Reality',
+    description:
+      'We specialize in creating innovative digital solutions that help businesses thrive in the modern world.',
+  },
+  contentSection: {
+    mainImage: {
+      id: 'main-1',
+      alt: 'Modern workspace',
+      url: '/website-template-OG.webp',
+      width: 1200,
+      height: 800,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    infoBox: {
+      icon: {
+        id: 'icon-1',
+        alt: 'Innovation icon',
+        url: '/website-template-OG.webp',
+        width: 48,
+        height: 48,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      title: 'Innovation at Core',
+      description: 'We bring cutting-edge solutions to every project we undertake.',
+      buttonLink: {
+        type: 'custom',
+        label: 'Learn More',
+        appearance: 'default',
+        url: '#',
+      },
+    },
+    sideImage: {
+      id: 'side-1',
+      alt: 'Team collaboration',
+      url: '/website-template-OG.webp',
+      width: 600,
+      height: 800,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  },
+  clientSection: {
+    title: 'Trusted by Industry Leaders',
+    clients: [
+      {
+        logo: {
+          id: 'client-1',
+          alt: 'Client 1',
+          url: '/website-template-OG.webp',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'TechCorp',
+      },
+      {
+        logo: {
+          id: 'client-2',
+          alt: 'Client 2',
+          url: '/website-template-OG.webp',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'InnovateLabs',
+      },
+      {
+        logo: {
+          id: 'client-3',
+          alt: 'Client 3',
+          url: '/website-template-OG.webp',
+          width: 200,
+          height: 60,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        name: 'FutureWorks',
+      },
+    ],
+  },
+  statsSection: {
+    title: 'Our Impact in Numbers',
+    description: 'We take pride in our achievements and the results we deliver to our clients.',
+    stats: [
+      { label: 'Projects Completed', value: '500+' },
+      { label: 'Happy Clients', value: '200+' },
+      { label: 'Team Members', value: '50+' },
+      { label: 'Years Experience', value: '15+' },
+    ],
+  },
+}
+
+export const Default: Story = {
+  args: defaultAbout,
+}
+
+export const WithoutImages: Story = {
+  args: {
+    ...defaultAbout,
+    contentSection: {
+      ...defaultAbout.contentSection,
+      mainImage: '',
+      infoBox: {
+        ...defaultAbout.contentSection.infoBox,
+        icon: '',
+      },
+      sideImage: '',
+    },
+    clientSection: {
+      ...defaultAbout.clientSection,
+      clients: defaultAbout.clientSection.clients?.map((client) => ({
+        ...client,
+        logo: '',
+      })),
+    },
+  },
+}
+
+export const WithMinimalFeature: Story = {
+  args: {
+    ...defaultAbout,
+    clientSection: {
+      title: 'Our Clients',
+      clients: [
+        {
+          logo: {
+            id: 'client-1',
+            alt: 'Client 1',
+            url: '/website-template-OG.webp',
+            width: 200,
+            height: 60,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          name: 'TechCorp',
+        },
+      ],
+    },
+    statsSection: {
+      title: 'Key Metrics',
+      description: 'Our core performance indicators',
+      stats: [
+        { label: 'Projects Completed', value: '500+' },
+        { label: 'Client Satisfaction', value: '99%' },
+      ],
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    ...defaultAbout,
+    mainSection: {
+      title: 'Leading the Digital Revolution',
+      description: 'Empowering businesses with next-generation solutions for the digital age.',
+    },
+    statsSection: {
+      ...defaultAbout.statsSection,
+      title: 'Achievement Highlights',
+      description: 'Our journey in numbers that speak for themselves.',
+    },
+  },
+}

--- a/src/blocks/About/components/About4/Component.tsx
+++ b/src/blocks/About/components/About4/Component.tsx
@@ -40,9 +40,11 @@ export default function About4({
           </div>
         </div>
 
-        <div className="mx-auto flex max-w-screen-lg flex-col items-center justify-between gap-8 rounded-2xl bg-muted/50 p-14 text-center md:flex-row md:text-left">
-          <h3 className="text-3xl font-semibold whitespace-pre-line">{ctaSection.title}</h3>
-          <CMSLink {...ctaSection.button} />
+        <div className="mx-auto flex max-w-screen-lg flex-col items-center justify-between gap-8 rounded-2xl bg-card/1 p-14 text-center md:flex-row md:text-left [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30 border border-border/100">
+          <h3 className="text-3xl font-semibold whitespace-pre-line [.theme-neon_&]:text-white">
+            {ctaSection.title}
+          </h3>
+          <CMSLink {...ctaSection.button} appearance="default" size="lg" />
         </div>
       </div>
     </section>

--- a/src/blocks/About/components/About4/Component.tsx
+++ b/src/blocks/About/components/About4/Component.tsx
@@ -17,9 +17,12 @@ export default function About4({
         </div>
 
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {gallerySection?.images?.map((image, index) => (
-            <Media key={index} resource={image.image} imgClassName="h-80 w-full object-cover" />
-          ))}
+          {gallerySection?.images?.map(
+            (image, index) =>
+              image.image && (
+                <Media key={index} resource={image.image} imgClassName="h-80 w-full object-cover" />
+              ),
+          )}
         </div>
 
         <div className="mx-auto grid max-w-screen-lg gap-28 py-28 md:grid-cols-2">

--- a/src/blocks/About/components/About4/component.stories.tsx
+++ b/src/blocks/About/components/About4/component.stories.tsx
@@ -1,0 +1,144 @@
+import { StoryObj, type Meta } from '@storybook/react'
+import type { About4Fields } from '@/payload-types'
+import About4 from './Component'
+
+const meta: Meta<typeof About4> = {
+  title: 'Blocks/About/About4',
+  component: About4,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof About4>
+
+const defaultAbout: About4Fields = {
+  mainSection: {
+    title: 'Meet Our Creative Team',
+    description:
+      'We are a group of passionate individuals dedicated to creating exceptional digital experiences.',
+  },
+  gallerySection: {
+    images: Array(6).fill({
+      image: {
+        id: 'gallery-1',
+        alt: 'Team member',
+        url: '/website-template-OG.webp',
+        width: 800,
+        height: 600,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    }),
+  },
+
+  contentSection: {
+    vision: {
+      title: 'Our Vision',
+      description:
+        'To revolutionize digital experiences through innovative solutions and creative excellence.',
+    },
+    creators: {
+      title: 'The Creators',
+      description:
+        'A diverse team of experts bringing unique perspectives and skills to every project.',
+    },
+  },
+  ctaSection: {
+    title: 'Ready to Start Your Project?',
+    button: {
+      type: 'custom',
+      label: 'Get in Touch',
+      appearance: 'outline',
+      url: '#contact',
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultAbout,
+}
+
+export const WithMinimalFeature: Story = {
+  args: {
+    ...defaultAbout,
+    gallerySection: {
+      images: Array(4).fill({
+        image: {
+          id: 'gallery-1',
+          alt: 'Team member',
+          url: '/website-template-OG.webp',
+          width: 800,
+          height: 600,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    },
+    contentSection: {
+      vision: {
+        title: 'Our Vision',
+        description: 'To revolutionize digital experiences through innovative solutions.',
+      },
+      creators: {
+        title: 'The Creators',
+        description: 'A diverse team of experts.',
+      },
+    },
+  },
+}
+
+export const WithoutImages: Story = {
+  args: {
+    ...defaultAbout,
+    gallerySection: {
+      images: Array(6).fill(''),
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    ...defaultAbout,
+    mainSection: {
+      title: 'Innovators in Digital Design',
+      description:
+        'Pushing the boundaries of whats possible in digital experiences and creative solutions.',
+    },
+    gallerySection: {
+      images: Array(6).fill({
+        image: {
+          id: 'gallery-1',
+          alt: 'Team member',
+          url: '/website-template-OG.webp',
+          width: 800,
+          height: 600,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    },
+    contentSection: {
+      vision: {
+        title: 'Looking Forward',
+        description:
+          'Shaping the future of digital interactions through innovative design and technology.',
+      },
+      creators: {
+        title: 'Our Team',
+        description:
+          'Bringing together the best talent from around the world to create exceptional experiences.',
+      },
+    },
+    ctaSection: {
+      title: 'Lets Create Something Amazing Together',
+      button: {
+        type: 'custom',
+        label: 'Start a Project',
+        appearance: 'outline',
+        url: '#start',
+      },
+    },
+  },
+}

--- a/src/blocks/About/components/About5/Component.tsx
+++ b/src/blocks/About/components/About5/Component.tsx
@@ -18,11 +18,13 @@ export default function About5({
           <p className="md:text-lg">{mainSection.description}</p>
         </div>
 
-        <Media
-          resource={imageSection.image}
-          className="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
-          imgClassName="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
-        />
+        {imageSection.image && (
+          <Media
+            resource={imageSection.image}
+            className="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
+            imgClassName="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
+          />
+        )}
         <p className="mt-6 text-center text-xl lg:text-right">{imageSection.caption}</p>
 
         <div className="flex flex-col gap-14 py-40 lg:flex-row">
@@ -30,13 +32,16 @@ export default function About5({
             {partnersSection.title}
           </p>
           <div className="grid grid-cols-2 items-center gap-6 md:grid-cols-4 max-w-2xl">
-            {partnersSection.partners?.map((partner, index) => (
-              <Media
-                key={index}
-                resource={partner.logo}
-                imgClassName="mx-auto h-20 md:mx-0 object-cover"
-              />
-            ))}
+            {partnersSection.partners?.map(
+              (partner, index) =>
+                partner.logo && (
+                  <Media
+                    key={index}
+                    resource={partner.logo}
+                    imgClassName="mx-auto h-20 md:mx-0 object-cover"
+                  />
+                ),
+            )}
           </div>
         </div>
 
@@ -56,11 +61,13 @@ export default function About5({
               ))}
             </div>
           </div>
-          <Media
-            resource={missionSection.image}
-            className="rounded-xl md:col-span-2"
-            imgClassName="rounded-xl w-full h-full object-cover"
-          />
+          {missionSection.image && (
+            <Media
+              resource={missionSection.image}
+              className="rounded-xl md:col-span-2"
+              imgClassName="rounded-xl w-full h-full object-cover"
+            />
+          )}
         </div>
       </div>
     </section>

--- a/src/blocks/About/components/About5/Component.tsx
+++ b/src/blocks/About/components/About5/Component.tsx
@@ -8,27 +8,35 @@ export default function About5({
   missionSection,
 }: About5Fields) {
   return (
-    <section className="bg-muted py-32">
+    <section className=" py-32 [.theme-neon_&]:bg-muted/20">
       <div className="container">
         <div className="grid gap-14 pb-32 md:grid-cols-2">
           <div>
-            <p className="text-sm font-medium">{mainSection.label}</p>
-            <h1 className="mt-4 text-3xl font-medium md:text-4xl">{mainSection.title}</h1>
+            <p className="text-sm font-medium text-foreground [.theme-neon_&]:text-black/80">
+              {mainSection.label}
+            </p>
+            <h1 className="mt-4 text-3xl font-medium md:text-4xl text-foreground [.theme-neon_&]:text-black">
+              {mainSection.title}
+            </h1>
           </div>
-          <p className="md:text-lg">{mainSection.description}</p>
+          <p className="md:text-lg text-muted-foreground [.theme-neon_&]:text-black/80">
+            {mainSection.description}
+          </p>
         </div>
 
         {imageSection.image && (
           <Media
             resource={imageSection.image}
-            className="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
+            className="ml-auto aspect-video max-h-[550px] rounded-xl object-cover border border-border/40"
             imgClassName="ml-auto aspect-video max-h-[550px] rounded-xl object-cover"
           />
         )}
-        <p className="mt-6 text-center text-xl lg:text-right">{imageSection.caption}</p>
+        <p className="mt-6 text-center text-xl lg:text-right text-muted-foreground [.theme-neon_&]:text-black/80">
+          {imageSection.caption}
+        </p>
 
         <div className="flex flex-col gap-14 py-40 lg:flex-row">
-          <p className="mx-auto max-w-xl text-center text-2xl lg:mx-0 lg:text-left">
+          <p className="mx-auto max-w-xl text-center text-2xl lg:mx-0 lg:text-left text-foreground [.theme-neon_&]:text-black">
             {partnersSection.title}
           </p>
           <div className="grid grid-cols-2 items-center gap-6 md:grid-cols-4 max-w-2xl">
@@ -38,7 +46,7 @@ export default function About5({
                   <Media
                     key={index}
                     resource={partner.logo}
-                    imgClassName="mx-auto h-20 md:mx-0 object-cover"
+                    imgClassName="mx-auto h-20 md:mx-0 object-cover [.theme-neon_&]:opacity-80"
                   />
                 ),
             )}
@@ -47,16 +55,24 @@ export default function About5({
 
         <div className="grid gap-14 lg:grid-cols-4 xl:grid-cols-5">
           <div className="md:col-span-2 xl:col-span-3">
-            <h2 className="mb-10 text-4xl font-medium">{missionSection.title}</h2>
-            <p className="text-lg whitespace-pre-line">{missionSection.description}</p>
+            <h2 className="mb-10 text-4xl font-medium text-foreground [.theme-neon_&]:text-black">
+              {missionSection.title}
+            </h2>
+            <p className="text-lg whitespace-pre-line text-muted-foreground [.theme-neon_&]:text-black/80">
+              {missionSection.description}
+            </p>
             <div className="mt-6 grid grid-cols-2 gap-6 text-center">
               {missionSection.stats?.map((stat, index) => (
                 <div
                   key={index}
-                  className="flex flex-col items-center justify-center gap-2 rounded-xl border bg-background p-6"
+                  className="flex flex-col items-center justify-center gap-2 rounded-xl border bg-card/1 p-6 backdrop-blur-sm [.theme-neon_&]:bg-black/95 [.theme-neon_&]:border-primary/30"
                 >
-                  <span className="text-2xl md:text-4xl">{stat.value}</span>
-                  <span className="text-sm text-muted-foreground md:text-lg">{stat.label}</span>
+                  <span className="text-2xl md:text-4xl font-medium  [.theme-neon_&]:text-black">
+                    {stat.value}
+                  </span>
+                  <span className="text-sm text-muted-foreground md:text-lg [.theme-neon_&]:text-white/80">
+                    {stat.label}
+                  </span>
                 </div>
               ))}
             </div>
@@ -64,7 +80,7 @@ export default function About5({
           {missionSection.image && (
             <Media
               resource={missionSection.image}
-              className="rounded-xl md:col-span-2"
+              className="rounded-xl md:col-span-2 border border-border/40"
               imgClassName="rounded-xl w-full h-full object-cover"
             />
           )}

--- a/src/blocks/About/components/About5/component.stories.tsx
+++ b/src/blocks/About/components/About5/component.stories.tsx
@@ -1,0 +1,141 @@
+import { StoryObj, type Meta } from '@storybook/react'
+import type { About5Fields } from '@/payload-types'
+import About5 from './Component'
+
+const meta: Meta<typeof About5> = {
+  title: 'Blocks/About/About5',
+  component: About5,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof About5>
+
+const defaultAbout: About5Fields = {
+  mainSection: {
+    label: 'ABOUT US',
+    title: 'Building Tomorrows Digital Solutions',
+    description:
+      'We are a team of passionate innovators dedicated to transforming ideas into impactful digital solutions that drive business growth and user engagement.',
+  },
+  imageSection: {
+    image: {
+      id: 'main-1',
+      alt: 'Team collaboration',
+      url: '/website-template-OG.webp',
+      width: 1200,
+      height: 675,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    caption: 'Our team collaborating on innovative solutions',
+  },
+  partnersSection: {
+    title: 'Trusted by Industry Leaders Worldwide',
+    partners: Array(4).fill({
+      logo: {
+        id: 'partner-1',
+        alt: 'Partner logo',
+        url: '/website-template-OG.webp',
+        width: 200,
+        height: 80,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    }),
+  },
+  missionSection: {
+    title: 'Our Mission and Impact',
+    description:
+      'We strive to create innovative solutions that empower businesses to thrive in the digital age. Through our commitment to excellence and continuous innovation, we help our clients achieve their goals and make a lasting impact.',
+    stats: [
+      { value: '500+', label: 'Projects Completed' },
+      { value: '95%', label: 'Client Satisfaction' },
+    ],
+    image: {
+      id: 'mission-1',
+      alt: 'Mission in action',
+      url: '/website-template-OG.webp',
+      width: 800,
+      height: 600,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultAbout,
+}
+
+export const WithMinimalFeature: Story = {
+  args: {
+    ...defaultAbout,
+    partnersSection: {
+      title: 'Our Partners',
+      partners: Array(4)
+        .fill({
+          logo: {
+            id: 'partner-1',
+            alt: 'Partner logo',
+            url: '/website-template-OG.webp',
+            width: 200,
+            height: 80,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        })
+        .slice(0, 2),
+    },
+    missionSection: {
+      ...defaultAbout.missionSection,
+      description:
+        'Creating innovative solutions that empower businesses to thrive in the digital age.',
+      stats: [{ value: '500+', label: 'Projects' }],
+    },
+  },
+}
+
+export const WithoutImages: Story = {
+  args: {
+    ...defaultAbout,
+    imageSection: {
+      image: '',
+      caption: 'Image caption placeholder',
+    },
+    partnersSection: {
+      title: 'Our Partners',
+      partners: Array(4).fill({
+        logo: '',
+      }),
+    },
+    missionSection: {
+      ...defaultAbout.missionSection,
+      image: '',
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    ...defaultAbout,
+    mainSection: {
+      label: 'OUR STORY',
+      title: 'Pioneering Digital Excellence',
+      description:
+        'Leading the way in digital transformation with innovative solutions and unparalleled expertise.',
+    },
+    missionSection: {
+      title: 'Driving Innovation Forward',
+      description:
+        'Our commitment to excellence and innovation helps businesses navigate the digital landscape and achieve sustainable growth.',
+      stats: [
+        { value: '10+', label: 'Years Experience' },
+        { value: '100%', label: 'Project Success' },
+      ],
+      image: defaultAbout.missionSection.image,
+    },
+  },
+}

--- a/src/blocks/About/components/About6/Component.tsx
+++ b/src/blocks/About/components/About6/Component.tsx
@@ -21,44 +21,56 @@ export default function About6({
             </div>
 
             <div className="flex flex-col items-center justify-center gap-6 md:flex-row">
-              <Media
-                resource={leftGallery.mainImage}
-                className="aspect-[0.7] w-full rounded-lg object-cover md:w-1/2"
-                imgClassName="aspect-[0.7] w-full rounded-lg object-cover"
-              />
+              {leftGallery.mainImage && (
+                <Media
+                  resource={leftGallery.mainImage}
+                  className="aspect-[0.7] w-full rounded-lg object-cover md:w-1/2"
+                  imgClassName="aspect-[0.7] w-full rounded-lg object-cover"
+                />
+              )}
               <div className="flex w-full flex-col items-center justify-center gap-6 md:w-1/2">
-                <Media
-                  resource={leftGallery.sideImages.first}
-                  className="aspect-[1.1] rounded-lg object-cover"
-                  imgClassName="aspect-[1.1] rounded-lg object-cover"
-                />
-                <Media
-                  resource={leftGallery.sideImages.second}
-                  className="aspect-[0.7] rounded-lg object-cover"
-                  imgClassName="aspect-[0.7] rounded-lg object-cover"
-                />
+                {leftGallery.sideImages.first && (
+                  <Media
+                    resource={leftGallery.sideImages.first}
+                    className="aspect-[1.1] rounded-lg object-cover"
+                    imgClassName="aspect-[1.1] rounded-lg object-cover"
+                  />
+                )}
+                {leftGallery.sideImages.second && (
+                  <Media
+                    resource={leftGallery.sideImages.second}
+                    className="aspect-[0.7] rounded-lg object-cover"
+                    imgClassName="aspect-[0.7] rounded-lg object-cover"
+                  />
+                )}
               </div>
             </div>
           </div>
 
           <div className="flex w-full flex-col items-center justify-center gap-12 pt-12 lg:w-1/2 lg:pt-48">
             <div className="flex flex-col items-center justify-center gap-6 md:flex-row">
-              <Media
-                resource={rightGallery.mainImage}
-                className="aspect-[0.9] w-full rounded-lg object-cover md:w-1/2"
-                imgClassName="aspect-[0.9] w-full rounded-lg object-cover"
-              />
+              {rightGallery.mainImage && (
+                <Media
+                  resource={rightGallery.mainImage}
+                  className="aspect-[0.9] w-full rounded-lg object-cover md:w-1/2"
+                  imgClassName="aspect-[0.9] w-full rounded-lg object-cover"
+                />
+              )}
               <div className="flex w-full flex-col items-center justify-center gap-6 md:w-1/2">
-                <Media
-                  resource={rightGallery.sideImages.first}
-                  className="aspect-[0.8] rounded-lg object-cover"
-                  imgClassName="aspect-[0.8] rounded-lg object-cover"
-                />
-                <Media
-                  resource={rightGallery.sideImages.second}
-                  className="aspect-[0.9] rounded-lg object-cover"
-                  imgClassName="aspect-[0.9] rounded-lg object-cover"
-                />
+                {rightGallery.sideImages.first && (
+                  <Media
+                    resource={rightGallery.sideImages.first}
+                    className="aspect-[0.8] rounded-lg object-cover"
+                    imgClassName="aspect-[0.8] rounded-lg object-cover"
+                  />
+                )}
+                {rightGallery.sideImages.second && (
+                  <Media
+                    resource={rightGallery.sideImages.second}
+                    className="aspect-[0.9] rounded-lg object-cover"
+                    imgClassName="aspect-[0.9] rounded-lg object-cover"
+                  />
+                )}
               </div>
             </div>
 

--- a/src/blocks/About/components/About6/component.stories.tsx
+++ b/src/blocks/About/components/About6/component.stories.tsx
@@ -1,0 +1,149 @@
+import { StoryObj, type Meta } from '@storybook/react'
+import type { About6Fields } from '@/payload-types'
+import About6 from './Component'
+
+const meta: Meta<typeof About6> = {
+  title: 'Blocks/About/About6',
+  component: About6,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof About6>
+
+const defaultAbout: About6Fields = {
+  storySection: {
+    title: 'Our Story',
+    description: 'Building innovative solutions since 2010',
+    content:
+      'We started with a vision to transform digital experiences. Today, we continue to innovate and push boundaries in technology and design, creating solutions that make a difference.',
+  },
+  leftGallery: {
+    mainImage: {
+      id: 'main-left',
+      alt: 'Team collaboration',
+      url: '/website-template-OG.webp',
+      width: 700,
+      height: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    sideImages: {
+      first: {
+        id: 'side-1-left',
+        alt: 'Office space',
+        url: '/website-template-OG.webp',
+        width: 1100,
+        height: 1000,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      second: {
+        id: 'side-2-left',
+        alt: 'Creative process',
+        url: '/website-template-OG.webp',
+        width: 700,
+        height: 1000,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  },
+  workplaceSection: {
+    title: 'Our Workplace',
+    description: 'A space designed for creativity and innovation',
+    content:
+      'Our workplace is more than just an office - its a hub of creativity, collaboration, and innovation where great ideas come to life.',
+  },
+  rightGallery: {
+    mainImage: {
+      id: 'main-right',
+      alt: 'Modern workplace',
+      url: '/website-template-OG.webp',
+      width: 900,
+      height: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    sideImages: {
+      first: {
+        id: 'side-1-right',
+        alt: 'Team meeting',
+        url: '/website-template-OG.webp',
+        width: 800,
+        height: 1000,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      second: {
+        id: 'side-2-right',
+        alt: 'Design process',
+        url: '/website-template-OG.webp',
+        width: 900,
+        height: 1000,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultAbout,
+}
+
+export const WithMinimalFeature: Story = {
+  args: {
+    ...defaultAbout,
+    storySection: {
+      title: 'Our Journey',
+      description: 'Creating digital excellence',
+      content: 'A focused approach to delivering innovative solutions.',
+    },
+    workplaceSection: {
+      title: 'Where We Work',
+      description: 'Innovation hub',
+      content: 'Our creative space where ideas transform into reality.',
+    },
+  },
+}
+
+export const WithoutImages: Story = {
+  args: {
+    ...defaultAbout,
+    leftGallery: {
+      mainImage: '',
+      sideImages: {
+        first: '',
+        second: '',
+      },
+    },
+    rightGallery: {
+      mainImage: '',
+      sideImages: {
+        first: '',
+        second: '',
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    ...defaultAbout,
+    storySection: {
+      title: 'Pioneering Digital Excellence',
+      description: 'Leading the way in digital innovation since 2010',
+      content:
+        'From humble beginnings to industry leadership, our journey has been defined by continuous innovation and unwavering commitment to excellence.',
+    },
+    workplaceSection: {
+      title: 'Culture of Innovation',
+      description: 'Where creativity meets technology',
+      content:
+        'Our workplace fosters collaboration, creativity, and breakthrough innovations that shape the future of digital experiences.',
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact1/Component.tsx
+++ b/src/blocks/Contact/components/Contact1/Component.tsx
@@ -55,11 +55,11 @@ export default function Contact1({ contact }: Contact1Fields) {
         <div className="flex w-full justify-center lg:mt-2.5">
           <div className="relative flex w-full min-w-[20rem] max-w-[30rem] flex-col items-center overflow-visible md:min-w-[24rem]">
             <div className="w-full z-10 space-y-6">
-              <div className="w-full space-y-6 rounded-xl border border-border bg-background px-6 py-10 shadow-sm">
+              <div className="w-full space-y-6 rounded-xl border border-border bg-background px-6 py-10 shadow-sm [.theme-neon_&]:bg-white [.theme-neon_&]:border-primary/30">
                 <Form
                   fields={form?.fields || []}
                   submitLabel={form?.submitButton?.label}
-                  className="flex flex-col gap-6"
+                  className="flex flex-col gap-6 text-foreground [.theme-neon_&]:text-black [.theme-neon_&]:placeholder-black/60"
                 />
               </div>
             </div>

--- a/src/blocks/Contact/components/Contact2/Component.tsx
+++ b/src/blocks/Contact/components/Contact2/Component.tsx
@@ -29,11 +29,11 @@ export default function Contact2({ contact }: Contact2Fields) {
               </ul>
             </div>
           </div>
-          <div className="mx-auto flex max-w-screen-md flex-col gap-6 rounded-lg border p-10">
+          <div className="mx-auto w-full max-w-lg flex flex-col gap-6 rounded-xl border p-12 bg-background [.theme-neon_&]:bg-white [.theme-neon_&]:border-primary/30">
             <Form
               fields={form?.fields || []}
               submitLabel={form?.submitButton?.label}
-              className="flex flex-col gap-6"
+              className="flex flex-col gap-8 text-foreground [.theme-neon_&]:text-black [.theme-neon_&]:placeholder-black/60"
             />
           </div>
         </div>

--- a/src/blocks/Contact/components/Contact2/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact2/component.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact2Fields } from '@/payload-types'
+import Contact2 from './Component'
+
+const meta: Meta<typeof Contact2> = {
+  title: 'Blocks/Contact/Contact2',
+  component: Contact2,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact2>
+
+const defaultContact: Contact2Fields = {
+  contact: {
+    title: 'Get in Touch',
+    description:
+      'Have questions? Were here to help. Send us a message and well respond as soon as possible.',
+    list: [
+      { text: 'Email: <a href="mailto:hello@example.com" class="underline">hello@example.com</a>' },
+      { text: 'Phone: <a href="tel:+1234567890" class="underline">+1 (234) 567-890</a>' },
+      { text: 'Address: 123 Business Street, Suite 100, San Francisco, CA 94111' },
+      { text: 'Hours: Monday - Friday, 9:00 AM - 6:00 PM PST' },
+    ],
+    form: {
+      fields: [
+        {
+          formField: {
+            label: 'Full Name',
+            placeholder: 'Enter your full name',
+            type: 'text',
+            required: 'yes',
+          },
+        },
+        {
+          formField: {
+            label: 'Email Address',
+            placeholder: 'you@example.com',
+            type: 'email',
+            required: 'yes',
+          },
+        },
+        {
+          formField: {
+            label: 'Subject',
+            placeholder: 'How can we help?',
+            type: 'text',
+            required: 'yes',
+          },
+        },
+        {
+          formField: {
+            label: 'Message',
+            placeholder: 'Tell us more about your needs...',
+            type: 'textarea',
+            required: 'yes',
+          },
+        },
+      ],
+      submitButton: {
+        label: 'Send Message',
+      },
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const MinimalContact: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      list: [
+        {
+          text: 'Email: <a href="mailto:hello@example.com" class="underline">hello@example.com</a>',
+        },
+        { text: 'Phone: <a href="tel:+1234567890" class="underline">+1 (234) 567-890</a>' },
+      ],
+    },
+  },
+}
+
+export const MinimalForm: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      form: {
+        fields: [
+          {
+            formField: {
+              label: 'Email',
+              placeholder: 'you@example.com',
+              type: 'email',
+              required: 'yes',
+            },
+          },
+          {
+            formField: {
+              label: 'Message',
+              placeholder: 'Your message',
+              type: 'textarea',
+              required: 'yes',
+            },
+          },
+        ],
+        submitButton: {
+          label: 'Send',
+        },
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Contact Our Support Team',
+      description:
+        'Our dedicated support team is available to assist you with any questions or concerns.',
+      list: [
+        {
+          text: 'Support: <a href="mailto:support@example.com" class="underline">support@example.com</a>',
+        },
+        {
+          text: 'Sales: <a href="mailto:sales@example.com" class="underline">sales@example.com</a>',
+        },
+        { text: 'Emergency Line: <a href="tel:+1800123456" class="underline">1-800-123-456</a>' },
+        { text: '24/7 Support Available' },
+      ],
+      form: defaultContact.contact.form,
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact3/Component.tsx
+++ b/src/blocks/Contact/components/Contact3/Component.tsx
@@ -22,7 +22,14 @@ export default function Contact3({ contact }: Contact3Fields) {
                 <div key={index} className="flex flex-col gap-2 sm:flex-row">
                   {Object.entries(linkGroup).map(
                     ([key, link]) =>
-                      link && typeof link === 'object' && <CMSLink key={key} {...link} />,
+                      link &&
+                      typeof link === 'object' && (
+                        <CMSLink
+                          key={key}
+                          {...link}
+                          className="bg-background text-foreground hover:bg-accent border border-border [.theme-neon_&]:bg-black [.theme-neon_&]:text-white [.theme-neon_&]:hover:bg-black/90 [.theme-neon_&]:border-primary/30"
+                        />
+                      ),
                   )}
                 </div>
               ))}

--- a/src/blocks/Contact/components/Contact3/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact3/component.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact3Fields } from '@/payload-types'
+import Contact3 from './Component'
+
+const meta: Meta<typeof Contact3> = {
+  title: 'Blocks/Contact/Contact3',
+  component: Contact3,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact3>
+
+const defaultContact: Contact3Fields = {
+  contact: {
+    title: 'Contact Us',
+    subtitle: 'Choose how you want to connect with us',
+    links: [
+      {
+        link: {
+          type: 'custom',
+          label: 'Start Live Chat',
+          url: '#chat',
+          appearance: 'secondary',
+        },
+      },
+      {
+        link: {
+          type: 'custom',
+          label: 'Schedule Call',
+          url: '#call',
+          appearance: 'outline',
+        },
+      },
+    ],
+    supportList: {
+      supports: [
+        {
+          icon: 'LifeBuoy',
+          title: 'Customer Support',
+          subtitle: 'Get help with your account or product',
+          link: {
+            type: 'custom',
+            label: 'Get Help',
+            url: '#help',
+            appearance: 'link',
+          },
+        },
+        {
+          icon: 'MessageCircle',
+          title: 'Sales Inquiries',
+          subtitle: 'Talk to our sales team about enterprise solutions',
+          link: {
+            type: 'custom',
+            label: 'Contact Sales',
+            url: '#sales',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+    officeList: {
+      title: 'Our Global Offices',
+      offices: [
+        {
+          title: 'San Francisco',
+          subtitle: '100 Main Street, CA 94105',
+        },
+        {
+          title: 'New York',
+          subtitle: '500 Broadway Street, NY 10012',
+        },
+        {
+          title: 'London',
+          subtitle: '123 King Street, EC2V 7EH',
+        },
+      ],
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const MinimalSupport: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      supportList: {
+        supports: defaultContact.contact.supportList?.supports?.[0]
+          ? [
+              {
+                icon: defaultContact.contact.supportList.supports[0].icon,
+                title: defaultContact.contact.supportList.supports[0].title,
+                subtitle: defaultContact.contact.supportList.supports[0].subtitle,
+                link: {
+                  type: 'custom',
+                  label: defaultContact.contact.supportList.supports[0].link.label,
+                  url: defaultContact.contact.supportList.supports[0].link.url,
+                  appearance: 'link',
+                },
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const SingleOffice: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      officeList: {
+        title: 'Our Main Office',
+        offices: defaultContact.contact.officeList?.offices?.[0]
+          ? [
+              {
+                title: defaultContact.contact.officeList.offices[0].title,
+                subtitle: defaultContact.contact.officeList.offices[0].subtitle,
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Need Help?',
+      subtitle: 'Our team is ready to assist you',
+      links: [
+        {
+          link: {
+            type: 'custom',
+            label: 'Start Live Chat',
+            url: '#chat',
+            appearance: 'secondary',
+          },
+        },
+        {
+          link: {
+            type: 'custom',
+            label: 'Schedule Call',
+            url: '#call',
+            appearance: 'outline',
+          },
+        },
+      ],
+      supportList: {
+        supports: [
+          {
+            icon: 'LifeBuoy',
+            title: 'Customer Support',
+            subtitle: 'Get help with your account or product',
+            link: {
+              type: 'custom',
+              label: 'Get Help',
+              url: '#help',
+              appearance: 'link',
+            },
+          },
+          {
+            icon: 'Building',
+            title: 'Enterprise Solutions',
+            subtitle: 'Custom solutions for large organizations',
+            link: {
+              type: 'custom',
+              label: 'Learn More',
+              url: '#enterprise',
+              appearance: 'link',
+            },
+          },
+        ],
+      },
+      officeList: defaultContact.contact.officeList,
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact4/Component.tsx
+++ b/src/blocks/Contact/components/Contact4/Component.tsx
@@ -49,16 +49,21 @@ export default function Contact4({ contact }: Contact4Fields) {
                     {location.image && (
                       <Media
                         resource={location.image}
-                        className="h-full w-full rounded-t-lg object-cover md:rounded-lg"
+                        className="h-full w-full rounded-t-lg object-cover md:rounded-lg bg-muted/20"
                       />
                     )}
-                    <div className="bottom-8 left-8 flex flex-col justify-between gap-6 rounded-b-lg border-x border-b bg-background p-6 md:absolute md:max-w-96 md:rounded-lg md:border">
+                    <div className="bottom-8 left-8 flex flex-col justify-between gap-6 rounded-b-lg border-x border-b bg-black/95 p-6 md:absolute md:max-w-96 md:rounded-lg md:border backdrop-blur-sm">
                       <div>
-                        <h2 className="mb-4 text-xl font-medium md:text-2xl">{location.title}</h2>
-                        <p className="text-muted-foreground">{location.subtitle}</p>
+                        <h2 className="mb-4 text-xl font-medium md:text-2xl text-white">
+                          {location.title}
+                        </h2>
+                        <p className="text-white/80">{location.subtitle}</p>
                       </div>
                       {location.link && (
-                        <CMSLink {...location.link} className="hover:underline w-fit" />
+                        <CMSLink
+                          {...location.link}
+                          className="hover:underline w-fit text-white hover:text-white/90"
+                        />
                       )}
                     </div>
                   </div>
@@ -66,8 +71,8 @@ export default function Contact4({ contact }: Contact4Fields) {
               ))}
             </CarouselContent>
             <div className="absolute bottom-2 right-6 flex gap-4 md:bottom-5 md:right-10">
-              <CarouselPrevious className="static" />
-              <CarouselNext className="static" />
+              <CarouselPrevious className="static bg-white hover:bg-white/90 text-black" />
+              <CarouselNext className="static bg-white hover:bg-white/90 text-black" />
             </div>
           </Carousel>
         </div>

--- a/src/blocks/Contact/components/Contact4/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact4/component.stories.tsx
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact4Fields } from '@/payload-types'
+import Contact4 from './Component'
+
+const meta: Meta<typeof Contact4> = {
+  title: 'Blocks/Contact/Contact4',
+  component: Contact4,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact4>
+
+const defaultContact: Contact4Fields = {
+  contact: {
+    title: 'Get in touch with us',
+    subtitle: 'Contact & Support',
+    supportList: {
+      supports: [
+        {
+          title: 'Sales Inquiries',
+          subtitle: 'For questions about our products and pricing',
+          link: {
+            type: 'custom',
+            label: 'Contact Sales',
+            url: '#sales',
+            appearance: 'link',
+          },
+        },
+        {
+          title: 'Technical Support',
+          subtitle: '24/7 technical assistance for our customers',
+          link: {
+            type: 'custom',
+            label: 'Get Support',
+            url: '#support',
+            appearance: 'link',
+          },
+        },
+        {
+          title: 'Media Relations',
+          subtitle: 'Press and media related inquiries',
+          link: {
+            type: 'custom',
+            label: 'Press Contact',
+            url: '#press',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+    locationList: {
+      locations: [
+        {
+          image: {
+            id: '1',
+            filename: 'sf-office.jpg',
+            alt: 'San Francisco Office',
+            url: '/website-template-OG.webp',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            mimeType: 'image/jpeg',
+            filesize: 1024,
+            width: 1920,
+            height: 1080,
+          },
+          title: 'San Francisco',
+          subtitle: '100 Market Street, Suite 300, San Francisco, CA 94105',
+          link: {
+            type: 'custom',
+            label: 'See on Google Maps',
+            url: '/website-template-OG.webp',
+            appearance: 'link',
+          },
+        },
+        {
+          image: {
+            id: '2',
+            filename: 'ny-office.jpg',
+            alt: 'New York Office',
+            url: '/website-template-OG.webp',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            mimeType: 'image/jpeg',
+            filesize: 1024,
+            width: 1920,
+            height: 1080,
+          },
+          title: 'New York',
+          subtitle: '500 Broadway Street, New York, NY 10012',
+          link: {
+            type: 'custom',
+            label: 'See on Google Maps',
+            url: '#ny-map',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const SingleSupport: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      supportList: {
+        supports: defaultContact.contact.supportList?.supports?.[0]
+          ? [
+              {
+                title: defaultContact.contact.supportList.supports[0].title,
+                subtitle: defaultContact.contact.supportList.supports[0].subtitle,
+                link: {
+                  type: 'custom',
+                  label: defaultContact.contact.supportList.supports[0].link.label,
+                  url: defaultContact.contact.supportList.supports[0].link.url,
+                  appearance: 'link',
+                },
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const SingleLocation: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      locationList: {
+        locations: defaultContact.contact.locationList?.locations?.[0]
+          ? [
+              {
+                image: defaultContact.contact.locationList.locations[0].image,
+                title: defaultContact.contact.locationList.locations[0].title,
+                subtitle: defaultContact.contact.locationList.locations[0].subtitle,
+                link: {
+                  type: 'custom',
+                  label: 'See on Google Maps',
+                  url: '#sf-map',
+                  appearance: 'link',
+                },
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Contact Our Teams',
+      subtitle: 'Were here to help',
+      supportList: {
+        supports: [
+          {
+            title: 'Enterprise Solutions',
+            subtitle: 'For large organizations and business inquiries',
+            link: {
+              type: 'custom',
+              label: 'Enterprise Contact',
+              url: '#enterprise',
+              appearance: 'link',
+            },
+          },
+          {
+            title: 'Customer Success',
+            subtitle: 'Get help with your account or service',
+            link: {
+              type: 'custom',
+              label: 'Contact Support',
+              url: '#support',
+              appearance: 'link',
+            },
+          },
+        ],
+      },
+      locationList: {
+        locations: defaultContact.contact.locationList?.locations || [],
+      },
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact5/Component.tsx
+++ b/src/blocks/Contact/components/Contact5/Component.tsx
@@ -16,7 +16,7 @@ export default function Contact5({ contact }: Contact5Fields) {
           <Form
             fields={form?.fields || []}
             submitLabel={form?.submitButton?.label}
-            className="flex flex-col gap-6"
+            className="flex flex-col gap-8 text-foreground [.theme-neon_&]:text-black [.theme-neon_&]:placeholder-black/6"
           />
         </div>
       </div>

--- a/src/blocks/Contact/components/Contact5/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact5/component.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact5Fields } from '@/payload-types'
+import Contact5 from './Component'
+
+const meta: Meta<typeof Contact5> = {
+  title: 'Blocks/Contact/Contact5',
+  component: Contact5,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact5>
+
+const defaultContact: Contact5Fields = {
+  contact: {
+    title: 'Get in Touch',
+    subtitle: 'Contact Us',
+    description: 'Fill out the form below and well get back to you as soon as possible.',
+    form: {
+      fields: [
+        {
+          formField: {
+            label: 'Full Name',
+            placeholder: 'Enter your full name',
+            required: 'yes',
+            type: 'text',
+          },
+        },
+        {
+          formField: {
+            label: 'Email Address',
+            placeholder: 'you@example.com',
+            required: 'yes',
+            type: 'email',
+          },
+        },
+        {
+          formField: {
+            label: 'Message',
+            placeholder: 'How can we help you?',
+            required: 'yes',
+            type: 'textarea',
+          },
+        },
+      ],
+      submitButton: {
+        label: 'Send Message',
+      },
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const MinimalFields: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      form: {
+        fields: [
+          {
+            formField: {
+              label: 'Email Address',
+              placeholder: 'you@example.com',
+              required: 'yes',
+              type: 'email',
+            },
+          },
+          {
+            formField: {
+              label: 'Message',
+              placeholder: 'Your message',
+              required: 'yes',
+              type: 'textarea',
+            },
+          },
+        ],
+        submitButton: {
+          label: 'Submit',
+        },
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Contact Support',
+      subtitle: 'Need Help?',
+      description: 'Our support team is here to assist you with any questions or concerns.',
+      form: {
+        fields: [
+          {
+            formField: {
+              label: 'Name',
+              placeholder: 'Your name',
+              required: 'yes',
+              type: 'text',
+            },
+          },
+          {
+            formField: {
+              label: 'Email',
+              placeholder: 'Your email',
+              required: 'yes',
+              type: 'email',
+            },
+          },
+          {
+            formField: {
+              label: 'Subject',
+              placeholder: 'What is this about?',
+              required: 'yes',
+              type: 'text',
+            },
+          },
+          {
+            formField: {
+              label: 'Message',
+              placeholder: 'Please describe your issue',
+              required: 'yes',
+              type: 'textarea',
+            },
+          },
+        ],
+        submitButton: {
+          label: 'Send Support Request',
+        },
+      },
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact6/Component.tsx
+++ b/src/blocks/Contact/components/Contact6/Component.tsx
@@ -19,9 +19,7 @@ export default function Contact6({ contact }: Contact6Fields) {
           <div className="grid gap-10 sm:grid-cols-2">
             {supportList?.supports?.map((support, idx) => (
               <div key={idx}>
-                {support.icon && (
-                  <DynamicIcon name={support.icon} className="mb-3 h-6 w-auto text-foreground" />
-                )}
+                {support.icon && <DynamicIcon name={support.icon} className="mb-3 h-6 w-auto  " />}
                 <p className="mb-2 text-lg font-semibold">{support.title}</p>
                 <p className="mb-3 text-muted-foreground">{support.subtitle}</p>
                 {support.link && (
@@ -35,7 +33,7 @@ export default function Contact6({ contact }: Contact6Fields) {
             <Form
               fields={form?.fields || []}
               submitLabel={form?.submitButton?.label}
-              className="flex flex-col gap-6"
+              className="flex flex-col gap-8 text-foreground [.theme-neon_&]:text-black [.theme-neon_&]:placeholder-black/6"
             />
           </div>
         </div>

--- a/src/blocks/Contact/components/Contact6/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact6/component.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact6Fields } from '@/payload-types'
+import Contact6 from './Component'
+
+const meta: Meta<typeof Contact6> = {
+  title: 'Blocks/Contact/Contact6',
+  component: Contact6,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact6>
+
+const defaultContact: Contact6Fields = {
+  contact: {
+    title: 'Get in Touch',
+    subtitle: 'Contact Us',
+    description: 'Have questions? We are here to help.',
+    supportList: {
+      supports: [
+        {
+          icon: 'Phone',
+          title: 'Sales Support',
+          subtitle: 'Talk to our sales team about enterprise solutions',
+          link: {
+            type: 'custom',
+            label: 'Contact Sales',
+            url: '#sales',
+            appearance: 'link',
+          },
+        },
+        {
+          icon: 'LifeBuoy',
+          title: 'Technical Support',
+          subtitle: '24/7 technical assistance for our customers',
+          link: {
+            type: 'custom',
+            label: 'Get Support',
+            url: '#support',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+    form: {
+      fields: [
+        {
+          formField: {
+            label: 'Full Name',
+            placeholder: 'Enter your full name',
+            required: 'yes',
+            type: 'text',
+          },
+        },
+        {
+          formField: {
+            label: 'Email Address',
+            placeholder: 'you@example.com',
+            required: 'yes',
+            type: 'email',
+          },
+        },
+        {
+          formField: {
+            label: 'Message',
+            placeholder: 'How can we help you?',
+            required: 'yes',
+            type: 'textarea',
+          },
+        },
+      ],
+      submitButton: {
+        label: 'Send Message',
+      },
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const SingleSupport: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      supportList: {
+        supports: defaultContact.contact.supportList?.supports?.[0]
+          ? [
+              {
+                icon: defaultContact.contact.supportList.supports[0].icon,
+                title: defaultContact.contact.supportList.supports[0].title,
+                subtitle: defaultContact.contact.supportList.supports[0].subtitle,
+                link: {
+                  type: 'custom',
+                  label: defaultContact.contact.supportList.supports[0].link.label,
+                  url: defaultContact.contact.supportList.supports[0].link.url,
+                  appearance: 'link',
+                },
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Contact Support',
+      subtitle: 'Need Help?',
+      description: 'Our support team is here to assist you.',
+      supportList: {
+        supports: [
+          {
+            icon: 'MessageSquare',
+            title: 'Live Chat',
+            subtitle: 'Chat with our support team in real-time',
+            link: {
+              type: 'custom',
+              label: 'Start Chat',
+              url: '#chat',
+              appearance: 'link',
+            },
+          },
+          {
+            icon: 'Mail',
+            title: 'Email Support',
+            subtitle: 'Send us an email and we will respond within 24 hours',
+            link: {
+              type: 'custom',
+              label: 'Email Us',
+              url: '#email',
+              appearance: 'link',
+            },
+          },
+        ],
+      },
+      form: {
+        fields: [
+          {
+            formField: {
+              label: 'Email',
+              placeholder: 'Your email address',
+              required: 'yes',
+              type: 'email',
+            },
+          },
+          {
+            formField: {
+              label: 'Issue Type',
+              placeholder: 'Select issue type',
+              required: 'yes',
+              type: 'select',
+              options: [
+                { label: 'Technical Issue', value: 'technical' },
+                { label: 'Billing Question', value: 'billing' },
+                { label: 'General Inquiry', value: 'general' },
+              ],
+            },
+          },
+          {
+            formField: {
+              label: 'Message',
+              placeholder: 'Describe your issue',
+              required: 'yes',
+              type: 'textarea',
+            },
+          },
+        ],
+        submitButton: {
+          label: 'Submit Request',
+        },
+      },
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact7/Component.tsx
+++ b/src/blocks/Contact/components/Contact7/Component.tsx
@@ -17,13 +17,16 @@ export default function Contact7({ contact }: Contact7Fields) {
         <div className="grid gap-10 md:grid-cols-3">
           {supportList?.supports?.map((support, idx) => (
             <div key={idx}>
-              <span className="mb-3 flex size-12 flex-col items-center justify-center rounded-full bg-accent">
+              <span className="mb-3 flex size-12 flex-col items-center justify-center rounded-full ">
                 {support.icon && <DynamicIcon name={support.icon} className="h-6 w-auto" />}
               </span>
               <p className="mb-2 text-lg font-semibold">{support.title}</p>
               <p className="mb-3 text-muted-foreground">{support.subtitle}</p>
               {support.link && (
-                <CMSLink {...support.link} className="font-semibold hover:underline w-fit" />
+                <CMSLink
+                  {...support.link}
+                  className="font-semibold hover:underline w-fit text-muted-foreground"
+                />
               )}
             </div>
           ))}

--- a/src/blocks/Contact/components/Contact7/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact7/component.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact7Fields } from '@/payload-types'
+import Contact7 from './Component'
+
+const meta: Meta<typeof Contact7> = {
+  title: 'Blocks/Contact/Contact7',
+  component: Contact7,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact7>
+
+const defaultContact: Contact7Fields = {
+  contact: {
+    title: 'Contact & Support',
+    subtitle: 'Get Help',
+    description: 'Choose the best way to get in touch with our team.',
+    supportList: {
+      supports: [
+        {
+          icon: 'Phone',
+          title: 'Sales Support',
+          subtitle: 'Talk to our sales team about enterprise solutions and pricing',
+          link: {
+            type: 'custom',
+            label: 'Contact Sales',
+            url: '#sales',
+            appearance: 'link',
+          },
+        },
+        {
+          icon: 'LifeBuoy',
+          title: 'Technical Support',
+          subtitle: '24/7 technical assistance for our customers',
+          link: {
+            type: 'custom',
+            label: 'Get Support',
+            url: '#support',
+            appearance: 'link',
+          },
+        },
+        {
+          icon: 'MessageCircle',
+          title: 'General Inquiries',
+          subtitle: 'Questions about our products or services',
+          link: {
+            type: 'custom',
+            label: 'Send Message',
+            url: '#contact',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const SingleSupport: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      supportList: {
+        supports: defaultContact.contact.supportList?.supports?.[0]
+          ? [
+              {
+                icon: defaultContact.contact.supportList.supports[0].icon,
+                title: defaultContact.contact.supportList.supports[0].title,
+                subtitle: defaultContact.contact.supportList.supports[0].subtitle,
+                link: {
+                  type: 'custom',
+                  label: defaultContact.contact.supportList.supports[0].link.label,
+                  url: defaultContact.contact.supportList.supports[0].link.url,
+                  appearance: 'link',
+                },
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Need Assistance?',
+      subtitle: 'Were Here to Help',
+      description: 'Choose your preferred method of contact below.',
+      supportList: {
+        supports: [
+          {
+            icon: 'MessageSquare',
+            title: 'Live Chat',
+            subtitle: 'Chat with our support team in real-time',
+            link: {
+              type: 'custom',
+              label: 'Start Chat',
+              url: '#chat',
+              appearance: 'link',
+            },
+          },
+          {
+            icon: 'Mail',
+            title: 'Email Support',
+            subtitle: 'Send us an email and well respond within 24 hours',
+            link: {
+              type: 'custom',
+              label: 'Email Us',
+              url: '#email',
+              appearance: 'link',
+            },
+          },
+          {
+            icon: 'PhoneCall',
+            title: 'Phone Support',
+            subtitle: 'Call us directly for immediate assistance',
+            link: {
+              type: 'custom',
+              label: 'Call Now',
+              url: '#phone',
+              appearance: 'link',
+            },
+          },
+        ],
+      },
+    },
+  },
+}

--- a/src/blocks/Contact/components/Contact8/Component.tsx
+++ b/src/blocks/Contact/components/Contact8/Component.tsx
@@ -9,14 +9,14 @@ export default function Contact8({ contact }: Contact8Fields) {
       <div className="container">
         <div className="text-center">
           <h1 className="mb-3 text-5xl font-bold">{title}</h1>
-          <p className="text-lg text-muted-foreground">{subtitle}</p>
+          <p className="text-lg ">{subtitle}</p>
         </div>
 
-        <div className="mx-auto mt-24 grid max-w-screen-xl gap-4 md:grid-cols-2">
+        <div className="mx-auto mt-24 grid max-w-screen-xl gap-4 md:grid-cols-2 ">
           {image && <Media resource={image} className="h-full rounded-lg object-cover" />}
 
-          <div className="flex flex-col gap-2 rounded-lg bg-accent p-2">
-            <div className="flex h-full flex-col justify-between gap-6 rounded-lg bg-background p-6">
+          <div className="flex flex-col gap-2 rounded-lg bg-accent p-2 bg-card/1">
+            <div className="flex h-full flex-col justify-between gap-6 rounded-lg  p-6">
               <p className="text-2xl">{supportList?.title}</p>
               <div className="flex flex-col">
                 {supportList?.supports?.map((link, idx) => (
@@ -28,7 +28,7 @@ export default function Contact8({ contact }: Contact8Fields) {
             </div>
 
             {officeList?.title && (
-              <div className="flex h-full flex-col justify-between gap-6 rounded-md bg-background p-6">
+              <div className="flex h-full flex-col justify-between gap-6 rounded-md  p-6">
                 <p className="text-2xl">{officeList.title}</p>
                 <div className="grid gap-8 md:grid-cols-2 md:gap-4">
                   {officeList.offices?.map((office, idx) => (

--- a/src/blocks/Contact/components/Contact8/component.stories.tsx
+++ b/src/blocks/Contact/components/Contact8/component.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { Contact8Fields } from '@/payload-types'
+import Contact8 from './Component'
+
+const meta: Meta<typeof Contact8> = {
+  title: 'Blocks/Contact/Contact8',
+  component: Contact8,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Contact8>
+
+const defaultContact: Contact8Fields = {
+  contact: {
+    title: 'Contact Us',
+    subtitle: 'Get in touch with our team',
+    image: {
+      id: '1',
+      filename: 'contact-image.jpg',
+      alt: 'Contact Image',
+      url: '/website-template-OG.webp',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      mimeType: 'image/webp',
+      filesize: 1024,
+      width: 1920,
+      height: 1080,
+    },
+    supportList: {
+      title: 'Support Options',
+      supports: [
+        {
+          link: {
+            type: 'custom',
+            label: 'Technical Support',
+            url: '#support',
+            appearance: 'link',
+          },
+        },
+        {
+          link: {
+            type: 'custom',
+            label: 'Sales Inquiries',
+            url: '#sales',
+            appearance: 'link',
+          },
+        },
+      ],
+    },
+    officeList: {
+      title: 'Our Offices',
+      offices: [
+        {
+          title: 'San Francisco',
+          subtitle: '100 Market Street, Suite 300, CA 94105',
+        },
+        {
+          title: 'New York',
+          subtitle: '500 Broadway Street, NY 10012',
+        },
+      ],
+    },
+  },
+}
+
+export const Default: Story = {
+  args: defaultContact,
+}
+
+export const SingleOffice: Story = {
+  args: {
+    contact: {
+      ...defaultContact.contact,
+      officeList: {
+        title: 'Main Office',
+        offices: defaultContact.contact.officeList?.offices?.[0]
+          ? [
+              {
+                title: defaultContact.contact.officeList.offices[0].title,
+                subtitle: defaultContact.contact.officeList.offices[0].subtitle,
+              },
+            ]
+          : [],
+      },
+    },
+  },
+}
+
+export const CustomContent: Story = {
+  args: {
+    contact: {
+      title: 'Get in Touch',
+      subtitle: 'We had love to hear from you',
+      image: {
+        id: '2',
+        filename: 'custom-contact.jpg',
+        alt: 'Custom Contact Image',
+        url: '/website-template-OG.webp',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        mimeType: 'image/webp',
+        filesize: 1024,
+        width: 1920,
+        height: 1080,
+      },
+      supportList: {
+        title: 'How Can We Help?',
+        supports: [
+          {
+            link: {
+              type: 'custom',
+              label: 'Customer Support',
+              url: '#customer-support',
+              appearance: 'link',
+            },
+          },
+          {
+            link: {
+              type: 'custom',
+              label: 'Enterprise Solutions',
+              url: '#enterprise',
+              appearance: 'link',
+            },
+          },
+        ],
+      },
+      officeList: {
+        title: 'Global Locations',
+        offices: [
+          {
+            title: 'London',
+            subtitle: '123 King Street, EC2V 7EH',
+          },
+          {
+            title: 'Singapore',
+            subtitle: '50 Raffles Place, 048623',
+          },
+        ],
+      },
+    },
+  },
+}

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -78,9 +78,19 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
     )
   }
 
+  // ... rest of the code remains the same ...
+
   return (
-    <Button asChild className={className} size={size} variant={appearance}>
-      <NextLink className={cn(className)} href={href || url || ''} {...newTabProps}>
+    <Button
+      asChild
+      className={cn(
+        '[.theme-neon_&]:bg-primary [.theme-neon_&]:text-primary-foreground [.theme-neon_&]:border-primary/50 [.theme-neon_&]:hover:bg-primary/90',
+        className,
+      )}
+      size={size}
+      variant={appearance}
+    >
+      <NextLink href={href || url || ''} {...newTabProps}>
         {content}
       </NextLink>
     </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: 'bg-background text-foreground hover:bg-accent hover:text-accent-foreground',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,11 +4,11 @@ import * as React from 'react'
 import { cn } from '@/utilities/ui'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-background text-foreground hover:bg-accent hover:text-accent-foreground',
+        default: 'bg-primary text-accent hover:bg-primary/90 hover:text-accent',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',


### PR DESCRIPTION
### About Components Collection Summary
I have implemented 5 distinct About components, each serving different presentation needs:

1. About2 : Corporate-focused with testimonials
   
   - Main content with image gallery
   - Statistics and partner showcase
   - Benefits and testimonial sections
2. About3 : Grid-based modern layout
   
   - Two-column main content
   - Featured image with info box
   - Client logos showcase
   - Statistics with decorative background
3. About4 : Team-centric presentation
   
   - Main content with description
   - 6-image team gallery
   - Vision and creators sections
   - Call-to-action integration
4. About5 : Professional profile design
   
   - Labeled sections with captions
   - Featured image showcase
   - Partner logos (4-column)
   - Mission statement with statistics
5. About6 : Story-driven dual gallery
   
   - Story section with content
   - Dual gallery system (left/right)
   - Workplace culture highlight
   - Precise image aspect ratios
Each component maintains four consistent story variants:

- Default (complete features)
- WithMinimalFeature (simplified)
- WithoutImages (text-only)
- CustomContent (alternative text)

you can access the video here:
https://www.loom.com/share/2d7cc78ed75e4c839281521ce2dcf896?sid=f4193944-b20f-44d7-90aa-deb9b51c513d

All components follow the design system's guidelines for typography, spacing, and responsiveness, ensuring a cohesive look across different screen sizes.