### PR TITLE
fix(56): Video Player Trigger Anywhere

### DIFF
--- a/src/blocks/VideoBlock/RenderVideo.tsx
+++ b/src/blocks/VideoBlock/RenderVideo.tsx
@@ -1,5 +1,7 @@
+'use client'
+
 import type { Media, VideoBlock as VideoBlockProps } from 'src/payload-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { Media as MediaComponent } from '@/components/Media'
 import { cn } from '@/utilities/ui'
 
@@ -8,6 +10,8 @@ type Props = {
 } & VideoBlockProps
 
 export const VideoBlock: React.FC<Props> = ({ className, videoType, url, caption, thumbnail }) => {
+  const [isVideoLoaded, setIsVideoLoaded] = useState(false)
+
   const getEmbedUrl = () => {
     if (!url) return null
 
@@ -27,21 +31,53 @@ export const VideoBlock: React.FC<Props> = ({ className, videoType, url, caption
   }
 
   const embedUrl = getEmbedUrl()
+  const isYouTube = videoType === 'youtube'
+
+  const handlePlayClick = () => {
+    setIsVideoLoaded(true)
+  }
 
   return (
     <div className={cn('my-4', className)}>
-      {thumbnail && typeof thumbnail === 'object' && (
-        <MediaComponent resource={thumbnail as Media} className="w-full h-auto rounded-md mb-2" />
-      )}
-
-      {embedUrl && (
+      {embedUrl && isYouTube && !isVideoLoaded ? (
+        <div className="relative w-full aspect-video rounded-md overflow-hidden">
+          {thumbnail && typeof thumbnail === 'object' ? (
+            <MediaComponent
+              resource={thumbnail as Media}
+              pictureClassName="!m-0"
+              imgClassName="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full bg-gray-200 flex items-center justify-center">
+              <span className="text-gray-500">Video thumbnail</span>
+            </div>
+          )}
+          <button
+            onClick={handlePlayClick}
+            className="absolute inset-0 flex items-center justify-center bg-black/30 hover:bg-black/40 transition-colors"
+            aria-label="Play video"
+          >
+            <div className="w-16 h-16 flex items-center justify-center rounded-full bg-red-600 text-white">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-8 h-8"
+                style={{ marginLeft: '2px' }}
+              >
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </div>
+          </button>
+        </div>
+      ) : embedUrl && (isYouTube ? isVideoLoaded : true) ? (
         <iframe
           src={embedUrl}
           className="w-full aspect-video rounded-md"
           allowFullScreen
           title="Embedded Video"
         />
-      )}
+      ) : null}
 
       {caption && <p className="text-sm text-gray-600 mt-2">{caption}</p>}
     </div>

--- a/src/blocks/VideoBlock/RenderVideo.tsx
+++ b/src/blocks/VideoBlock/RenderVideo.tsx
@@ -62,8 +62,7 @@ export const VideoBlock: React.FC<Props> = ({ className, videoType, url, caption
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="w-8 h-8"
-                style={{ marginLeft: '2px' }}
+                className="w-8 h-8 ml-0.5"
               >
                 <path d="M8 5v14l11-7z" />
               </svg>
@@ -79,7 +78,7 @@ export const VideoBlock: React.FC<Props> = ({ className, videoType, url, caption
         />
       ) : null}
 
-      {caption && <p className="text-sm text-gray-600 mt-2">{caption}</p>}
+      {caption && <p className="text-sm text-gray-600 mt-2 text-center">{caption}</p>}
     </div>
   )
 }

--- a/src/components/Media/ImageMedia/index.tsx
+++ b/src/components/Media/ImageMedia/index.tsx
@@ -18,6 +18,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
   const {
     alt: altFromProps,
     fill,
+    pictureClassName,
     imgClassName,
     priority,
     resource,
@@ -59,7 +60,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
         .join(', ')
 
   return (
-    <picture>
+    <picture className={cn(pictureClassName)}>
       <NextImage
         alt={alt || ''}
         className={cn(imgClassName)}

--- a/src/components/Media/types.ts
+++ b/src/components/Media/types.ts
@@ -17,4 +17,5 @@ export interface Props {
   size?: string // for NextImage only
   src?: StaticImageData // for static media
   videoClassName?: string
+  pictureClassName?: string
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2785,7 +2785,7 @@ export interface Product {
           /**
            * Choose how the link should be rendered.
            */
-          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
+          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
         };
         id?: string | null;
       }[]


### PR DESCRIPTION
## Description
This feature implements a complete "lazy load" for YouTube videos in the `VideoBlock` component. By deferring the loading of video resources until the play button is triggered, we aim to significantly reduce the Largest Contentful Paint (LCP) and improve overall page speed. This approach is inspired by a similar solution I implemented using WordPress and Bricks Builder.

## Motivation
Page speed is crucial for user experience and SEO. By not loading any YouTube video resources until the user interacts with the play button, we can enhance performance and ensure that our pages load faster. This change will also help in scenarios where auto-play videos are not required.

## Implementation Details
- The `VideoBlock` component will now only set the embed URL for YouTube videos when the play button is clicked.
- This change will prevent unnecessary loading of video resources, thereby optimizing the loading time of the page.

## Benefits
- Improved page speed and performance metrics.
- Enhanced user experience by reducing initial load times.
- Better SEO performance due to lower LCP values.

Please review the changes and provide feedback!