### PR TITLE
feat(link): add advanced field to hero sections

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -34,7 +34,6 @@ import {
   RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
 } from '@payloadcms/richtext-lexical/rsc'
-import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 import { default as default_a48147a5d9e361c38690affd82c29136 } from 'src/collections/CustomCodes/components/ScriptRowLabel'
 import { default as default_b128d0bd7c3a2b8021c74b08f7767dc4 } from '@/blocks/About/components/About1/config.client.tsx'
 import { default as default_c3b518973acc8f136eb7ceedd0826569 } from '@/blocks/CallToAction/components/CTA1/client'
@@ -163,8 +162,6 @@ export const importMap = {
     TenantSelector_1d0591e3cf4f332c83a86da13a0de59a,
   '@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider':
     TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62,
-  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
-    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
   '@/components/views/WordpressMigration/DefaultRootView#DefaultRootView':
     DefaultRootView_a5b063f5b2b9cdce4f0e1dd9b2761872,
 }

--- a/src/fields/link.ts
+++ b/src/fields/link.ts
@@ -5,11 +5,26 @@ import { icon } from './icon'
 export type LinkAppearances = 'default' | 'secondary' | 'outline' | 'ghost' | 'link'
 
 export const appearanceOptions: Record<LinkAppearances, { label: string; value: string }> = {
-  default: { label: 'Default', value: 'default' },
-  secondary: { label: 'Secondary', value: 'secondary' },
-  outline: { label: 'Outline', value: 'outline' },
-  ghost: { label: 'Ghost', value: 'ghost' },
-  link: { label: 'Link', value: 'link' },
+  default: { 
+    label: 'Default',
+    value: 'default'
+  },
+  secondary: { 
+    label: 'Secondary',
+    value: 'secondary'
+  },
+  outline: { 
+    label: 'Outline', 
+    value: 'outline' 
+  },
+  ghost: { 
+    label: 'Ghost', 
+    value: 'ghost' 
+  },
+  link: { 
+    label: 'Link', 
+    value: 'link' 
+  },
 }
 
 type LinkUIEnhancements = {
@@ -34,7 +49,13 @@ export const link: LinkType = ({
   label,
   appearances,
   disableLabel = false,
-  ui = { image: false, title: false, subtitle: false, description: false, icons: true },
+  ui = { 
+    image: false, 
+    title: false, 
+    subtitle: false, 
+    description: false, 
+    icons: true 
+  },
   overrides = {},
 } = {}) => {
   const linkResult: GroupField = {
@@ -76,7 +97,9 @@ export const link: LinkType = ({
     {
       name: 'reference',
       type: 'relationship',
-      admin: { condition: (_, siblingData) => siblingData?.type === 'reference' },
+      admin: { 
+        condition: (_, siblingData) => siblingData?.type === 'reference' 
+      },
       label: 'Document to link to',
       relationTo: ['pages', 'posts'],
       required: true,
@@ -84,7 +107,9 @@ export const link: LinkType = ({
     {
       name: 'url',
       type: 'text',
-      admin: { condition: (_, siblingData) => siblingData?.type === 'custom' },
+      admin: { 
+        condition: (_, siblingData) => siblingData?.type === 'custom' 
+      },
       label: 'Custom URL',
       required: true,
     },
@@ -103,7 +128,14 @@ export const link: LinkType = ({
       type: 'row',
       fields: [
         ...linkTypes,
-        { name: 'label', type: 'text', admin: { width: '50%' }, label: 'Label', required: true },
+        { 
+          name: 'label', 
+          type: 'text', 
+          admin: { 
+            width: '50%' 
+          }, 
+          label: 'Label', 
+          required: true },
       ],
     })
   } else {
@@ -135,7 +167,10 @@ export const link: LinkType = ({
     advancedFields.push({
       name: 'appearance',
       type: 'select',
-      admin: { description: 'Choose how the link should be rendered.', width: '50%' },
+      admin: { 
+        description: 'Choose how the link should be rendered.', 
+        width: '50%' 
+      },
       defaultValue: 'default',
       options: appearanceOptionsToUse,
     })
@@ -172,14 +207,26 @@ export const link: LinkType = ({
   if (ui.title) {
     linkResult.fields.push({
       type: 'row',
-      fields: [{ name: 'title', type: 'text', admin: { description: 'Title for the link' } }],
+      fields: [{ 
+        name: 'title', 
+        type: 'text',
+        admin: {
+          description: 'Title for the link'
+        } 
+      }],
     })
   }
 
   if (ui.subtitle) {
     linkResult.fields.push({
       type: 'row',
-      fields: [{ name: 'subtitle', type: 'text', admin: { description: 'Subtitle for the link' } }],
+      fields: [{ 
+        name: 'subtitle', 
+        type: 'text', 
+        admin: { 
+          description: 'Subtitle for the link' 
+        }
+      }],
     })
   }
 
@@ -190,7 +237,9 @@ export const link: LinkType = ({
         {
           name: 'description',
           type: 'textarea',
-          admin: { description: 'Description for the link' },
+          admin: { 
+            description: 'Description for the link' 
+          },
         },
       ],
     })

--- a/src/fields/link.ts
+++ b/src/fields/link.ts
@@ -1,29 +1,28 @@
 import type { Field, GroupField } from 'payload'
 import deepMerge from '@/utilities/deepMerge'
-import { icon } from './icon'
 
 export type LinkAppearances = 'default' | 'secondary' | 'outline' | 'ghost' | 'link'
 
 export const appearanceOptions: Record<LinkAppearances, { label: string; value: string }> = {
-  default: { 
+  default: {
     label: 'Default',
-    value: 'default'
+    value: 'default',
   },
-  secondary: { 
+  secondary: {
     label: 'Secondary',
-    value: 'secondary'
+    value: 'secondary',
   },
-  outline: { 
-    label: 'Outline', 
-    value: 'outline' 
+  outline: {
+    label: 'Outline',
+    value: 'outline',
   },
-  ghost: { 
-    label: 'Ghost', 
-    value: 'ghost' 
+  ghost: {
+    label: 'Ghost',
+    value: 'ghost',
   },
-  link: { 
-    label: 'Link', 
-    value: 'link' 
+  link: {
+    label: 'Link',
+    value: 'link',
   },
 }
 
@@ -49,12 +48,12 @@ export const link: LinkType = ({
   label,
   appearances,
   disableLabel = false,
-  ui = { 
-    image: false, 
-    title: false, 
-    subtitle: false, 
-    description: false, 
-    icons: true 
+  ui = {
+    image: false,
+    title: false,
+    subtitle: false,
+    description: false,
+    icons: true,
   },
   overrides = {},
 } = {}) => {
@@ -79,14 +78,22 @@ export const link: LinkType = ({
             ],
           },
           {
-            name: 'newTab',
-            type: 'checkbox',
+            name: 'appearance', // Moved here
+            type: 'select',
             admin: {
-              condition: (_, siblingData) => siblingData?.type !== 'popup',
-              style: { alignSelf: 'flex-end' },
+              description: 'Choose how the link should be rendered.',
               width: '50%',
             },
-            label: 'Open in new tab',
+            defaultValue: 'default',
+            options: appearances
+              ? appearances.map((appearance) => appearanceOptions[appearance])
+              : [
+                  appearanceOptions.default,
+                  appearanceOptions.secondary,
+                  appearanceOptions.outline,
+                  appearanceOptions.ghost,
+                  appearanceOptions.link,
+                ],
           },
         ],
       },
@@ -97,8 +104,8 @@ export const link: LinkType = ({
     {
       name: 'reference',
       type: 'relationship',
-      admin: { 
-        condition: (_, siblingData) => siblingData?.type === 'reference' 
+      admin: {
+        condition: (_, siblingData) => siblingData?.type === 'reference',
       },
       label: 'Document to link to',
       relationTo: ['pages', 'posts'],
@@ -107,8 +114,8 @@ export const link: LinkType = ({
     {
       name: 'url',
       type: 'text',
-      admin: { 
-        condition: (_, siblingData) => siblingData?.type === 'custom' 
+      admin: {
+        condition: (_, siblingData) => siblingData?.type === 'custom',
       },
       label: 'Custom URL',
       required: true,
@@ -128,14 +135,15 @@ export const link: LinkType = ({
       type: 'row',
       fields: [
         ...linkTypes,
-        { 
-          name: 'label', 
-          type: 'text', 
-          admin: { 
-            width: '50%' 
-          }, 
-          label: 'Label', 
-          required: true },
+        {
+          name: 'label',
+          type: 'text',
+          admin: {
+            width: '50%',
+          },
+          label: 'Label',
+          required: true,
+        },
       ],
     })
   } else {
@@ -145,48 +153,47 @@ export const link: LinkType = ({
   const advancedFields: Field[] = []
 
   if (ui.icons) {
-    advancedFields.push(
-      icon({ name: 'prefixIcon', label: 'Prefix Icon' }),
-      icon({ name: 'suffixIcon', label: 'Suffix Icon' }),
-    )
-  }
-
-  if (appearances !== false) {
-    let appearanceOptionsToUse = [
-      appearanceOptions.default,
-      appearanceOptions.secondary,
-      appearanceOptions.outline,
-      appearanceOptions.ghost,
-      appearanceOptions.link,
-    ]
-
-    if (appearances) {
-      appearanceOptionsToUse = appearances.map((appearance) => appearanceOptions[appearance])
-    }
-
     advancedFields.push({
-      name: 'appearance',
-      type: 'select',
-      admin: { 
-        description: 'Choose how the link should be rendered.', 
-        width: '50%' 
-      },
-      defaultValue: 'default',
-      options: appearanceOptionsToUse,
+      type: 'row',
+      fields: [
+        {
+          name: 'prefixIcon',
+          type: 'text', // Use 'text' or proper type for the icon
+          admin: {
+            width: '50%',
+          },
+          label: 'Prefix Icon',
+        },
+        {
+          name: 'suffixIcon',
+          type: 'text', // Use 'text' or proper type for the icon
+          admin: {
+            width: '50%',
+          },
+          label: 'Suffix Icon',
+        },
+      ],
     })
   }
+
+  // Moved 'Open in new tab' to Advanced section
+  advancedFields.push({
+    name: 'newTab',
+    type: 'checkbox',
+    admin: {
+      condition: (_, siblingData) => siblingData?.type !== 'popup',
+      style: { alignSelf: 'flex-end' },
+      width: '50%',
+    },
+    label: 'Open in new tab',
+  })
 
   if (advancedFields.length > 0) {
     linkResult.fields.push({
       type: 'collapsible',
       label: 'Advanced',
       admin: { initCollapsed: true },
-      fields: [
-        {
-          type: 'row',
-          fields: advancedFields,
-        },
-      ],
+      fields: advancedFields,
     })
   }
 
@@ -207,26 +214,30 @@ export const link: LinkType = ({
   if (ui.title) {
     linkResult.fields.push({
       type: 'row',
-      fields: [{ 
-        name: 'title', 
-        type: 'text',
-        admin: {
-          description: 'Title for the link'
-        } 
-      }],
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          admin: {
+            description: 'Title for the link',
+          },
+        },
+      ],
     })
   }
 
   if (ui.subtitle) {
     linkResult.fields.push({
       type: 'row',
-      fields: [{ 
-        name: 'subtitle', 
-        type: 'text', 
-        admin: { 
-          description: 'Subtitle for the link' 
-        }
-      }],
+      fields: [
+        {
+          name: 'subtitle',
+          type: 'text',
+          admin: {
+            description: 'Subtitle for the link',
+          },
+        },
+      ],
     })
   }
 
@@ -237,8 +248,8 @@ export const link: LinkType = ({
         {
           name: 'description',
           type: 'textarea',
-          admin: { 
-            description: 'Description for the link' 
+          admin: {
+            description: 'Description for the link',
           },
         },
       ],

--- a/src/fields/slug/link.ts
+++ b/src/fields/slug/link.ts
@@ -1,6 +1,6 @@
 import type { Field, GroupField } from 'payload'
 import deepMerge from '@/utilities/deepMerge'
-import { icon } from './icon'
+import { icon } from '../icon'
 
 export type LinkAppearances = 'default' | 'secondary' | 'outline' | 'ghost' | 'link'
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2197,13 +2197,13 @@ export interface CTA3Fields {
           prefixIcon?: string | null;
           suffixIcon?: string | null;
           /**
-           * Description for the link
-           */
-          description?: string | null;
-          /**
            * Choose how the link should be rendered.
            */
           appearance?: 'ghost' | null;
+          /**
+           * Description for the link
+           */
+          description?: string | null;
         };
         /**
          * Brief description of the feature
@@ -6559,6 +6559,10 @@ export interface Header3Fields {
                 url?: string | null;
                 popup?: (string | null) | Popup;
                 /**
+                 * Choose how the link should be rendered.
+                 */
+                appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                /**
                  * Image URL for the link
                  */
                 image?: (string | null) | Media;
@@ -6570,10 +6574,6 @@ export interface Header3Fields {
                  * Description for the link
                  */
                 description?: string | null;
-                /**
-                 * Choose how the link should be rendered.
-                 */
-                appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               };
             };
             rightSection: {
@@ -6597,6 +6597,10 @@ export interface Header3Fields {
                       prefixIcon?: string | null;
                       suffixIcon?: string | null;
                       /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      /**
                        * Title for the link
                        */
                       title?: string | null;
@@ -6604,10 +6608,6 @@ export interface Header3Fields {
                        * Description for the link
                        */
                       description?: string | null;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                     };
                     id?: string | null;
                   }[]
@@ -6727,6 +6727,10 @@ export interface Header3Fields {
                       url?: string | null;
                       popup?: (string | null) | Popup;
                       /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      /**
                        * Image URL for the link
                        */
                       image?: (string | null) | Media;
@@ -6738,10 +6742,6 @@ export interface Header3Fields {
                        * Description for the link
                        */
                       description?: string | null;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                     };
                     id?: string | null;
                   }[]
@@ -9904,8 +9904,8 @@ export interface CTA3FieldsSelect<T extends boolean = true> {
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              description?: T;
               appearance?: T;
+              description?: T;
             };
         description?: T;
         id?: T;
@@ -12262,10 +12262,10 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                 reference?: T;
                                 url?: T;
                                 popup?: T;
+                                appearance?: T;
                                 image?: T;
                                 title?: T;
                                 description?: T;
-                                appearance?: T;
                               };
                         };
                     rightSection?:
@@ -12285,9 +12285,9 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                       popup?: T;
                                       prefixIcon?: T;
                                       suffixIcon?: T;
+                                      appearance?: T;
                                       title?: T;
                                       description?: T;
-                                      appearance?: T;
                                     };
                                 id?: T;
                               };
@@ -12376,10 +12376,10 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
+                                      appearance?: T;
                                       image?: T;
                                       title?: T;
                                       description?: T;
-                                      appearance?: T;
                                     };
                                 id?: T;
                               };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -326,7 +326,10 @@ export interface Hero1Fields {
       | {
           'link-1': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -341,17 +344,17 @@ export interface Hero1Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Hero button with ArrowDownRight suffix icon
            */
           'link-2': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -366,10 +369,7 @@ export interface Hero1Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -665,7 +665,10 @@ export interface Hero5Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -680,10 +683,7 @@ export interface Hero5Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -712,7 +712,10 @@ export interface Hero7Fields {
      */
     link: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -727,10 +730,7 @@ export interface Hero7Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
     /**
      * Rating information
@@ -787,7 +787,10 @@ export interface Hero8Fields {
       | {
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -802,10 +805,7 @@ export interface Hero8Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -844,7 +844,10 @@ export interface Hero12Fields {
       | {
           'link-1': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -859,17 +862,17 @@ export interface Hero12Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Hero button with ExternalLink suffix icon
            */
           'link-2': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -884,10 +887,7 @@ export interface Hero12Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -941,7 +941,10 @@ export interface Hero24Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -956,10 +959,7 @@ export interface Hero24Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1017,7 +1017,10 @@ export interface Hero25Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1032,10 +1035,7 @@ export interface Hero25Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1080,7 +1080,10 @@ export interface Hero32Fields {
      */
     link: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -1095,10 +1098,7 @@ export interface Hero32Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
     /**
      * Integration images (exactly 15)
@@ -1149,7 +1149,10 @@ export interface Hero34Fields {
            */
           'link-1': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1164,14 +1167,14 @@ export interface Hero34Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           'link-2': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1186,10 +1189,7 @@ export interface Hero34Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1224,7 +1224,10 @@ export interface Hero6Fields {
       | {
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1239,10 +1242,7 @@ export interface Hero6Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1306,7 +1306,10 @@ export interface Hero3Fields {
       | {
           'link-1': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1321,17 +1324,17 @@ export interface Hero3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Hero button with ArrowDownRight suffix icon
            */
           'link-2': {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1346,10 +1349,7 @@ export interface Hero3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1456,7 +1456,10 @@ export interface Hero115Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -1471,10 +1474,7 @@ export interface Hero115Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -1757,7 +1757,10 @@ export interface About3Fields {
        */
       buttonLink: {
         type?: ('reference' | 'custom' | 'popup') | null;
-        newTab?: boolean | null;
+        /**
+         * Choose how the link should be rendered.
+         */
+        appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
         reference?:
           | ({
               relationTo: 'pages';
@@ -1772,10 +1775,7 @@ export interface About3Fields {
         label: string;
         prefixIcon?: string | null;
         suffixIcon?: string | null;
-        /**
-         * Choose how the link should be rendered.
-         */
-        appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+        newTab?: boolean | null;
       };
     };
     /**
@@ -1893,7 +1893,10 @@ export interface About4Fields {
      */
     button: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -1908,10 +1911,7 @@ export interface About4Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
   };
 }
@@ -2104,7 +2104,10 @@ export interface CTA1Fields {
    */
   btn: {
     type?: ('reference' | 'custom' | 'popup') | null;
-    newTab?: boolean | null;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: 'default' | null;
     reference?:
       | ({
           relationTo: 'pages';
@@ -2119,10 +2122,7 @@ export interface CTA1Fields {
     label: string;
     prefixIcon?: string | null;
     suffixIcon?: string | null;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: 'default' | null;
+    newTab?: boolean | null;
   };
 }
 /**
@@ -2148,7 +2148,10 @@ export interface CTA3Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: 'default' | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2163,10 +2166,7 @@ export interface CTA3Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: 'default' | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2181,7 +2181,10 @@ export interface CTA3Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: 'ghost' | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2196,10 +2199,7 @@ export interface CTA3Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: 'ghost' | null;
+          newTab?: boolean | null;
           /**
            * Description for the link
            */
@@ -2236,7 +2236,10 @@ export interface CTA4Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: 'default' | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2251,10 +2254,7 @@ export interface CTA4Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: 'default' | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2300,7 +2300,10 @@ export interface CTA5Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: 'default' | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2315,10 +2318,7 @@ export interface CTA5Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: 'default' | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2347,7 +2347,10 @@ export interface CTA7Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: 'default' | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2362,10 +2365,7 @@ export interface CTA7Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: 'default' | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2407,7 +2407,10 @@ export interface CTA10Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'ghost') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2422,10 +2425,7 @@ export interface CTA10Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'ghost') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2454,7 +2454,10 @@ export interface CTA11Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'ghost') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2469,10 +2472,7 @@ export interface CTA11Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'ghost') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2509,7 +2509,10 @@ export interface CTA15Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'ghost') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2524,10 +2527,7 @@ export interface CTA15Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'ghost') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2561,7 +2561,10 @@ export interface CTA16Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'ghost') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2576,10 +2579,7 @@ export interface CTA16Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'ghost') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2608,7 +2608,10 @@ export interface CTA17Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'ghost') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2623,10 +2626,7 @@ export interface CTA17Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'ghost') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2658,7 +2658,10 @@ export interface ContentBlock {
         enableLink?: boolean | null;
         link?: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2673,10 +2676,7 @@ export interface ContentBlock {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -2798,7 +2798,10 @@ export interface Product {
     | {
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -2813,10 +2816,7 @@ export interface Product {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -3168,7 +3168,10 @@ export interface Gallery1Fields {
      */
     link: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -3183,10 +3186,7 @@ export interface Gallery1Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
     /**
      * Gallery image
@@ -3337,7 +3337,10 @@ export interface Gallery5Fields {
       | {
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -3352,10 +3355,7 @@ export interface Gallery5Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -3404,7 +3404,10 @@ export interface Gallery6Fields {
      */
     link: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -3419,10 +3422,7 @@ export interface Gallery6Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
     /**
      * Gallery cards (3-6)
@@ -3442,7 +3442,10 @@ export interface Gallery6Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -3457,10 +3460,7 @@ export interface Gallery6Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Card image
@@ -3577,7 +3577,10 @@ export interface Feature1Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -3592,10 +3595,7 @@ export interface Feature1Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -3629,7 +3629,10 @@ export interface Feature2Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -3644,10 +3647,7 @@ export interface Feature2Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -3848,7 +3848,10 @@ export interface Feature11Fields {
          */
         link: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -3863,10 +3866,7 @@ export interface Feature11Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         id?: string | null;
       }[]
@@ -4176,7 +4176,10 @@ export interface Testimonial7Fields {
    */
   cta: {
     type?: ('reference' | 'custom' | 'popup') | null;
-    newTab?: boolean | null;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
     reference?:
       | ({
           relationTo: 'pages';
@@ -4191,10 +4194,7 @@ export interface Testimonial7Fields {
     label: string;
     prefixIcon?: string | null;
     suffixIcon?: string | null;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+    newTab?: boolean | null;
   };
   /**
    * Testimonial items (4-12)
@@ -4333,7 +4333,10 @@ export interface Testimonial15Fields {
    */
   cta: {
     type?: ('reference' | 'custom' | 'popup') | null;
-    newTab?: boolean | null;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
     reference?:
       | ({
           relationTo: 'pages';
@@ -4348,10 +4351,7 @@ export interface Testimonial15Fields {
     label: string;
     prefixIcon?: string | null;
     suffixIcon?: string | null;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+    newTab?: boolean | null;
   };
   /**
    * Company section configuration
@@ -4544,7 +4544,10 @@ export interface Testimonial19Fields {
    */
   viewAll: {
     type?: ('reference' | 'custom' | 'popup') | null;
-    newTab?: boolean | null;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
     reference?:
       | ({
           relationTo: 'pages';
@@ -4559,10 +4562,7 @@ export interface Testimonial19Fields {
     label: string;
     prefixIcon?: string | null;
     suffixIcon?: string | null;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+    newTab?: boolean | null;
   };
   /**
    * Testimonial items (3-12)
@@ -4836,7 +4836,10 @@ export interface Contact3Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -4851,10 +4854,7 @@ export interface Contact3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -4885,7 +4885,10 @@ export interface Contact3Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -4900,10 +4903,7 @@ export interface Contact3Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -4975,7 +4975,10 @@ export interface Contact4Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -4990,10 +4993,7 @@ export interface Contact4Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -5025,7 +5025,10 @@ export interface Contact4Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -5040,10 +5043,7 @@ export interface Contact4Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -5174,7 +5174,10 @@ export interface Contact6Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -5189,10 +5192,7 @@ export interface Contact6Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -5300,7 +5300,10 @@ export interface Contact7Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -5315,10 +5318,7 @@ export interface Contact7Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -5365,7 +5365,10 @@ export interface Contact8Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -5380,10 +5383,7 @@ export interface Contact8Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -5530,7 +5530,10 @@ export interface Team2Fields {
                  */
                 link?: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -5544,10 +5547,7 @@ export interface Team2Fields {
                   popup?: (string | null) | Popup;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -5588,7 +5588,10 @@ export interface Team3Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -5603,10 +5606,7 @@ export interface Team3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -5642,7 +5642,10 @@ export interface Team3Fields {
                  */
                 link?: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -5656,10 +5659,7 @@ export interface Team3Fields {
                   popup?: (string | null) | Popup;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -5700,7 +5700,10 @@ export interface Team5Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -5715,10 +5718,7 @@ export interface Team5Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -5801,7 +5801,10 @@ export interface Team6Fields {
                  */
                 link?: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -5815,10 +5818,7 @@ export interface Team6Fields {
                   popup?: (string | null) | Popup;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -5932,7 +5932,10 @@ export interface FAQ3Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -5947,10 +5950,7 @@ export interface FAQ3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -6007,7 +6007,10 @@ export interface FAQ4Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6022,10 +6025,7 @@ export interface FAQ4Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -6153,7 +6153,10 @@ export interface Logos2Fields {
      */
     link: {
       type?: ('reference' | 'custom' | 'popup') | null;
-      newTab?: boolean | null;
+      /**
+       * Choose how the link should be rendered.
+       */
+      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
       reference?:
         | ({
             relationTo: 'pages';
@@ -6168,10 +6171,7 @@ export interface Logos2Fields {
       label: string;
       prefixIcon?: string | null;
       suffixIcon?: string | null;
-      /**
-       * Choose how the link should be rendered.
-       */
-      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+      newTab?: boolean | null;
     };
     /**
      * Logo images (6 required)
@@ -6255,7 +6255,10 @@ export interface LinkPopupBlock {
    */
   link: {
     type?: ('reference' | 'custom' | 'popup') | null;
-    newTab?: boolean | null;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
     reference?:
       | ({
           relationTo: 'pages';
@@ -6270,10 +6273,7 @@ export interface LinkPopupBlock {
     label: string;
     prefixIcon?: string | null;
     suffixIcon?: string | null;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+    newTab?: boolean | null;
   };
   id?: string | null;
   blockName?: string | null;
@@ -6380,7 +6380,10 @@ export interface Header1Fields {
            */
           parentLink: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6395,10 +6398,7 @@ export interface Header1Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Links in this column
@@ -6410,7 +6410,10 @@ export interface Header1Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -6425,10 +6428,7 @@ export interface Header1Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 /**
                  * Description for this sub menu
@@ -6447,7 +6447,10 @@ export interface Header1Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6462,10 +6465,7 @@ export interface Header1Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -6489,7 +6489,10 @@ export interface Header3Fields {
       | {
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6504,10 +6507,7 @@ export interface Header3Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -6520,7 +6520,10 @@ export interface Header3Fields {
          */
         parentMenu: {
           type?: ('reference' | 'custom' | 'popup') | null;
-          newTab?: boolean | null;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
           reference?:
             | ({
                 relationTo: 'pages';
@@ -6535,10 +6538,7 @@ export interface Header3Fields {
           label: string;
           prefixIcon?: string | null;
           suffixIcon?: string | null;
-          /**
-           * Choose how the link should be rendered.
-           */
-          appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+          newTab?: boolean | null;
         };
         submenu?: {
           style?: ('style-1' | 'style-2' | 'style-3' | 'style-4') | null;
@@ -6546,7 +6546,10 @@ export interface Header3Fields {
             leftSection?: {
               link?: {
                 type?: ('reference' | 'custom' | 'popup') | null;
-                newTab?: boolean | null;
+                /**
+                 * Choose how the link should be rendered.
+                 */
+                appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                 reference?:
                   | ({
                       relationTo: 'pages';
@@ -6558,10 +6561,7 @@ export interface Header3Fields {
                     } | null);
                 url?: string | null;
                 popup?: (string | null) | Popup;
-                /**
-                 * Choose how the link should be rendered.
-                 */
-                appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                newTab?: boolean | null;
                 /**
                  * Image URL for the link
                  */
@@ -6582,7 +6582,10 @@ export interface Header3Fields {
                 | {
                     link?: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6596,10 +6599,7 @@ export interface Header3Fields {
                       popup?: (string | null) | Popup;
                       prefixIcon?: string | null;
                       suffixIcon?: string | null;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      newTab?: boolean | null;
                       /**
                        * Title for the link
                        */
@@ -6621,7 +6621,10 @@ export interface Header3Fields {
                 | {
                     link: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6636,10 +6639,7 @@ export interface Header3Fields {
                       label: string;
                       prefixIcon?: string | null;
                       suffixIcon?: string | null;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      newTab?: boolean | null;
                     };
                     id?: string | null;
                   }[]
@@ -6648,7 +6648,10 @@ export interface Header3Fields {
             rightSection?: {
               link?: {
                 type?: ('reference' | 'custom' | 'popup') | null;
-                newTab?: boolean | null;
+                /**
+                 * Choose how the link should be rendered.
+                 */
+                appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                 reference?:
                   | ({
                       relationTo: 'pages';
@@ -6660,6 +6663,7 @@ export interface Header3Fields {
                     } | null);
                 url?: string | null;
                 popup?: (string | null) | Popup;
+                newTab?: boolean | null;
                 /**
                  * Image URL for the link
                  */
@@ -6687,7 +6691,10 @@ export interface Header3Fields {
                 | {
                     link: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6700,10 +6707,7 @@ export interface Header3Fields {
                       url?: string | null;
                       popup?: (string | null) | Popup;
                       label: string;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      newTab?: boolean | null;
                     };
                     id?: string | null;
                   }[]
@@ -6714,7 +6718,10 @@ export interface Header3Fields {
                 | {
                     link?: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6726,10 +6733,7 @@ export interface Header3Fields {
                           } | null);
                       url?: string | null;
                       popup?: (string | null) | Popup;
-                      /**
-                       * Choose how the link should be rendered.
-                       */
-                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                      newTab?: boolean | null;
                       /**
                        * Image URL for the link
                        */
@@ -6755,7 +6759,10 @@ export interface Header3Fields {
                 | {
                     link?: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6767,6 +6774,7 @@ export interface Header3Fields {
                           } | null);
                       url?: string | null;
                       popup?: (string | null) | Popup;
+                      newTab?: boolean | null;
                       /**
                        * Title for the link
                        */
@@ -6786,7 +6794,10 @@ export interface Header3Fields {
                 | {
                     link?: {
                       type?: ('reference' | 'custom' | 'popup') | null;
-                      newTab?: boolean | null;
+                      /**
+                       * Choose how the link should be rendered.
+                       */
+                      appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                       reference?:
                         | ({
                             relationTo: 'pages';
@@ -6798,6 +6809,7 @@ export interface Header3Fields {
                           } | null);
                       url?: string | null;
                       popup?: (string | null) | Popup;
+                      newTab?: boolean | null;
                       /**
                        * Image URL for the link
                        */
@@ -6845,7 +6857,10 @@ export interface Header5Fields {
            */
           parentLink: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6860,10 +6875,7 @@ export interface Header5Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           /**
            * Links in this column
@@ -6875,7 +6887,10 @@ export interface Header5Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -6890,10 +6905,7 @@ export interface Header5Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 /**
                  * Description for this sub menu
@@ -6912,7 +6924,10 @@ export interface Header5Fields {
            */
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -6927,10 +6942,7 @@ export interface Header5Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -7010,7 +7022,10 @@ export interface Footer1Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7025,10 +7040,7 @@ export interface Footer1Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7054,7 +7066,10 @@ export interface Footer1Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7068,10 +7083,7 @@ export interface Footer1Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7123,7 +7135,10 @@ export interface Footer2Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7138,10 +7153,7 @@ export interface Footer2Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7157,7 +7169,10 @@ export interface Footer2Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7172,10 +7187,7 @@ export interface Footer2Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7219,7 +7231,10 @@ export interface Footer3Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7234,10 +7249,7 @@ export interface Footer3Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7253,7 +7265,10 @@ export interface Footer3Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7268,10 +7283,7 @@ export interface Footer3Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7285,7 +7297,10 @@ export interface Footer3Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7299,10 +7314,7 @@ export interface Footer3Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7346,7 +7358,10 @@ export interface Footer4Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7361,10 +7376,7 @@ export interface Footer4Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7380,7 +7392,10 @@ export interface Footer4Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7395,10 +7410,7 @@ export interface Footer4Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7412,7 +7424,10 @@ export interface Footer4Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7426,10 +7441,7 @@ export interface Footer4Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7479,7 +7491,10 @@ export interface Footer5Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7494,10 +7509,7 @@ export interface Footer5Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7517,7 +7529,10 @@ export interface Footer5Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7531,10 +7546,7 @@ export interface Footer5Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7552,7 +7564,10 @@ export interface Footer5Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7566,10 +7581,7 @@ export interface Footer5Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7621,7 +7633,10 @@ export interface Footer6Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7636,10 +7651,7 @@ export interface Footer6Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7655,7 +7667,10 @@ export interface Footer6Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7670,10 +7685,7 @@ export interface Footer6Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7725,7 +7737,10 @@ export interface Footer7Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7740,10 +7755,7 @@ export interface Footer7Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7759,7 +7771,10 @@ export interface Footer7Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7773,10 +7788,7 @@ export interface Footer7Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7790,7 +7802,10 @@ export interface Footer7Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7805,10 +7820,7 @@ export interface Footer7Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7856,7 +7868,10 @@ export interface Footer8Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -7871,10 +7886,7 @@ export interface Footer8Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -7890,7 +7902,10 @@ export interface Footer8Fields {
              */
             link?: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -7904,10 +7919,7 @@ export interface Footer8Fields {
               popup?: (string | null) | Popup;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -7950,7 +7962,10 @@ export interface Footer9Fields {
       | {
           link: {
             type?: ('reference' | 'custom' | 'popup') | null;
-            newTab?: boolean | null;
+            /**
+             * Choose how the link should be rendered.
+             */
+            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
             reference?:
               | ({
                   relationTo: 'pages';
@@ -7965,10 +7980,7 @@ export interface Footer9Fields {
             label: string;
             prefixIcon?: string | null;
             suffixIcon?: string | null;
-            /**
-             * Choose how the link should be rendered.
-             */
-            appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+            newTab?: boolean | null;
           };
           id?: string | null;
         }[]
@@ -7992,7 +8004,10 @@ export interface Footer9Fields {
                  */
                 link: {
                   type?: ('reference' | 'custom' | 'popup') | null;
-                  newTab?: boolean | null;
+                  /**
+                   * Choose how the link should be rendered.
+                   */
+                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
                   reference?:
                     | ({
                         relationTo: 'pages';
@@ -8007,10 +8022,7 @@ export interface Footer9Fields {
                   label: string;
                   prefixIcon?: string | null;
                   suffixIcon?: string | null;
-                  /**
-                   * Choose how the link should be rendered.
-                   */
-                  appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+                  newTab?: boolean | null;
                 };
                 id?: string | null;
               }[]
@@ -8030,7 +8042,10 @@ export interface Footer9Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -8045,10 +8060,7 @@ export interface Footer9Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -8062,7 +8074,10 @@ export interface Footer9Fields {
              */
             link: {
               type?: ('reference' | 'custom' | 'popup') | null;
-              newTab?: boolean | null;
+              /**
+               * Choose how the link should be rendered.
+               */
+              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
               reference?:
                 | ({
                     relationTo: 'pages';
@@ -8077,10 +8092,7 @@ export interface Footer9Fields {
               label: string;
               prefixIcon?: string | null;
               suffixIcon?: string | null;
-              /**
-               * Choose how the link should be rendered.
-               */
-              appearance?: ('default' | 'secondary' | 'outline' | 'ghost' | 'link') | null;
+              newTab?: boolean | null;
             };
             id?: string | null;
           }[]
@@ -9001,27 +9013,27 @@ export interface Hero1FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               'link-2'?:
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9045,14 +9057,14 @@ export interface Hero5FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9072,14 +9084,14 @@ export interface Hero7FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         rating?:
           | T
@@ -9113,14 +9125,14 @@ export interface Hero8FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9145,27 +9157,27 @@ export interface Hero12FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               'link-2'?:
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9196,14 +9208,14 @@ export interface Hero24FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9235,14 +9247,14 @@ export interface Hero25FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9269,14 +9281,14 @@ export interface Hero32FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         integrations?:
           | T
@@ -9305,27 +9317,27 @@ export interface Hero34FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               'link-2'?:
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9349,14 +9361,14 @@ export interface Hero6FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9396,27 +9408,27 @@ export interface Hero3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               'link-2'?:
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9473,14 +9485,14 @@ export interface Hero115FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -9643,14 +9655,14 @@ export interface About3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
             };
         sideImage?: T;
@@ -9726,14 +9738,14 @@ export interface About4FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
       };
 }
@@ -9855,14 +9867,14 @@ export interface CTA1FieldsSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
-        newTab?: T;
+        appearance?: T;
         reference?: T;
         url?: T;
         popup?: T;
         label?: T;
         prefixIcon?: T;
         suffixIcon?: T;
-        appearance?: T;
+        newTab?: T;
       };
 }
 /**
@@ -9879,14 +9891,14 @@ export interface CTA3FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -9897,14 +9909,14 @@ export interface CTA3FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
               description?: T;
             };
         description?: T;
@@ -9925,14 +9937,14 @@ export interface CTA4FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -9959,14 +9971,14 @@ export interface CTA5FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -9985,14 +9997,14 @@ export interface CTA7FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10018,14 +10030,14 @@ export interface CTA10FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10044,14 +10056,14 @@ export interface CTA11FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10072,14 +10084,14 @@ export interface CTA15FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10100,14 +10112,14 @@ export interface CTA16FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10126,14 +10138,14 @@ export interface CTA17FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10153,14 +10165,14 @@ export interface ContentBlockSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10230,14 +10242,14 @@ export interface Gallery1FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         image?: T;
         items?:
@@ -10316,14 +10328,14 @@ export interface Gallery5FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -10351,14 +10363,14 @@ export interface Gallery6FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         cards?:
           | T
@@ -10369,14 +10381,14 @@ export interface Gallery6FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               image?: T;
               id?: T;
@@ -10440,14 +10452,14 @@ export interface Feature1FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10468,14 +10480,14 @@ export interface Feature2FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10585,14 +10597,14 @@ export interface Feature11FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };
@@ -10777,14 +10789,14 @@ export interface Testimonial7FieldsSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
-        newTab?: T;
+        appearance?: T;
         reference?: T;
         url?: T;
         popup?: T;
         label?: T;
         prefixIcon?: T;
         suffixIcon?: T;
-        appearance?: T;
+        newTab?: T;
       };
   testimonials?:
     | T
@@ -10846,14 +10858,14 @@ export interface Testimonial15FieldsSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
-        newTab?: T;
+        appearance?: T;
         reference?: T;
         url?: T;
         popup?: T;
         label?: T;
         prefixIcon?: T;
         suffixIcon?: T;
-        appearance?: T;
+        newTab?: T;
       };
   companySection?:
     | T
@@ -10941,14 +10953,14 @@ export interface Testimonial19FieldsSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
-        newTab?: T;
+        appearance?: T;
         reference?: T;
         url?: T;
         popup?: T;
         label?: T;
         prefixIcon?: T;
         suffixIcon?: T;
-        appearance?: T;
+        newTab?: T;
       };
   testimonials?:
     | T
@@ -11102,14 +11114,14 @@ export interface Contact3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -11126,14 +11138,14 @@ export interface Contact3FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11174,14 +11186,14 @@ export interface Contact4FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11199,14 +11211,14 @@ export interface Contact4FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11279,14 +11291,14 @@ export interface Contact6FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11346,14 +11358,14 @@ export interface Contact7FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11382,14 +11394,14 @@ export interface Contact8FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11469,13 +11481,13 @@ export interface Team2FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11501,14 +11513,14 @@ export interface Team3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -11526,13 +11538,13 @@ export interface Team3FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11558,14 +11570,14 @@ export interface Team5FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -11605,13 +11617,13 @@ export interface Team6FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -11688,14 +11700,14 @@ export interface FAQ3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -11728,14 +11740,14 @@ export interface FAQ4FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -11817,14 +11829,14 @@ export interface Logos2FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         logos?:
           | T
@@ -11878,14 +11890,14 @@ export interface LinkPopupBlockSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
-        newTab?: T;
+        appearance?: T;
         reference?: T;
         url?: T;
         popup?: T;
         label?: T;
         prefixIcon?: T;
         suffixIcon?: T;
-        appearance?: T;
+        newTab?: T;
       };
   id?: T;
   blockName?: T;
@@ -12150,14 +12162,14 @@ export interface Header1FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               subMenu?:
                 | T
@@ -12166,14 +12178,14 @@ export interface Header1FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     description?: T;
                     id?: T;
@@ -12187,14 +12199,14 @@ export interface Header1FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -12216,14 +12228,14 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -12235,14 +12247,14 @@ export interface Header3FieldsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         submenu?:
           | T
@@ -12258,11 +12270,11 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                             | T
                             | {
                                 type?: T;
-                                newTab?: T;
+                                appearance?: T;
                                 reference?: T;
                                 url?: T;
                                 popup?: T;
-                                appearance?: T;
+                                newTab?: T;
                                 image?: T;
                                 title?: T;
                                 description?: T;
@@ -12279,13 +12291,13 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
                                       prefixIcon?: T;
                                       suffixIcon?: T;
-                                      appearance?: T;
+                                      newTab?: T;
                                       title?: T;
                                       description?: T;
                                     };
@@ -12307,14 +12319,14 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
                                       label?: T;
                                       prefixIcon?: T;
                                       suffixIcon?: T;
-                                      appearance?: T;
+                                      newTab?: T;
                                     };
                                 id?: T;
                               };
@@ -12326,10 +12338,11 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                             | T
                             | {
                                 type?: T;
-                                newTab?: T;
+                                appearance?: T;
                                 reference?: T;
                                 url?: T;
                                 popup?: T;
+                                newTab?: T;
                                 image?: T;
                                 title?: T;
                                 subtitle?: T;
@@ -12352,12 +12365,12 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
                                       label?: T;
-                                      appearance?: T;
+                                      newTab?: T;
                                     };
                                 id?: T;
                               };
@@ -12372,11 +12385,11 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
-                                      appearance?: T;
+                                      newTab?: T;
                                       image?: T;
                                       title?: T;
                                       description?: T;
@@ -12399,10 +12412,11 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
+                                      newTab?: T;
                                       title?: T;
                                       description?: T;
                                     };
@@ -12420,10 +12434,11 @@ export interface Header3FieldsSelect<T extends boolean = true> {
                                   | T
                                   | {
                                       type?: T;
-                                      newTab?: T;
+                                      appearance?: T;
                                       reference?: T;
                                       url?: T;
                                       popup?: T;
+                                      newTab?: T;
                                       image?: T;
                                       title?: T;
                                       description?: T;
@@ -12453,14 +12468,14 @@ export interface Header5FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               subMenus?:
                 | T
@@ -12469,14 +12484,14 @@ export interface Header5FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     description?: T;
                     id?: T;
@@ -12490,14 +12505,14 @@ export interface Header5FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -12545,14 +12560,14 @@ export interface Footer1FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12569,13 +12584,13 @@ export interface Footer1FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12605,14 +12620,14 @@ export interface Footer2FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12628,14 +12643,14 @@ export interface Footer2FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12663,14 +12678,14 @@ export interface Footer3FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12686,14 +12701,14 @@ export interface Footer3FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12708,13 +12723,13 @@ export interface Footer3FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12742,14 +12757,14 @@ export interface Footer4FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12765,14 +12780,14 @@ export interface Footer4FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12787,13 +12802,13 @@ export interface Footer4FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12826,14 +12841,14 @@ export interface Footer5FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12850,13 +12865,13 @@ export interface Footer5FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12872,13 +12887,13 @@ export interface Footer5FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12908,14 +12923,14 @@ export interface Footer6FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12931,14 +12946,14 @@ export interface Footer6FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12968,14 +12983,14 @@ export interface Footer7FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -12991,13 +13006,13 @@ export interface Footer7FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13012,14 +13027,14 @@ export interface Footer7FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13048,14 +13063,14 @@ export interface Footer8FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13071,13 +13086,13 @@ export interface Footer8FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13108,14 +13123,14 @@ export interface Footer9FieldsSelect<T extends boolean = true> {
                 | T
                 | {
                     type?: T;
-                    newTab?: T;
+                    appearance?: T;
                     reference?: T;
                     url?: T;
                     popup?: T;
                     label?: T;
                     prefixIcon?: T;
                     suffixIcon?: T;
-                    appearance?: T;
+                    newTab?: T;
                   };
               id?: T;
             };
@@ -13130,14 +13145,14 @@ export interface Footer9FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13154,14 +13169,14 @@ export interface Footer9FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13176,14 +13191,14 @@ export interface Footer9FieldsSelect<T extends boolean = true> {
                       | T
                       | {
                           type?: T;
-                          newTab?: T;
+                          appearance?: T;
                           reference?: T;
                           url?: T;
                           popup?: T;
                           label?: T;
                           prefixIcon?: T;
                           suffixIcon?: T;
-                          appearance?: T;
+                          newTab?: T;
                         };
                     id?: T;
                   };
@@ -13390,14 +13405,14 @@ export interface ProductsSelect<T extends boolean = true> {
           | T
           | {
               type?: T;
-              newTab?: T;
+              appearance?: T;
               reference?: T;
               url?: T;
               popup?: T;
               label?: T;
               prefixIcon?: T;
               suffixIcon?: T;
-              appearance?: T;
+              newTab?: T;
             };
         id?: T;
       };


### PR DESCRIPTION
Changed the link component: used AdvancedFields to shorten the Prefix Icon, Suffix Icon and Appearance fields by default in the optional Advanced section to free up the user interface.